### PR TITLE
Fix GetHistograms method strconv.ParseInt function's parameter error

### DIFF
--- a/log_store.go
+++ b/log_store.go
@@ -282,7 +282,7 @@ func (s *LogStore) GetHistograms(topic string, from int64, to int64, queryExp st
 		return nil, err
 	}
 
-	count, err := strconv.ParseInt(r.Header[GetLogsCountHeader][0], 10, 32)
+	count, err := strconv.ParseInt(r.Header[GetLogsCountHeader][0], 10, 64)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
由于 strconv.ParseInt 的 bitSize 设置成了 32，count 大于 int32 会报错。bitSize 改为 64 即可。
```
strconv.ParseInt: parsing "22893216268": value out of range
```