### PR TITLE
fix producer callback function

### DIFF
--- a/producer/io_worker.go
+++ b/producer/io_worker.go
@@ -109,6 +109,7 @@ func (ioWorker *IoWorker) closeSendTask(ioWorkerWaitGroup *sync.WaitGroup) {
 
 func (ioWorker *IoWorker) excuteFailedCallback(producerBatch *ProducerBatch) {
 	level.Info(ioWorker.logger).Log("msg", "sendToServer failed,Execute failed callback function")
+	atomic.AddInt64(&producerLogGroupSize, -producerBatch.totalDataSize)
 	if len(producerBatch.callBackList) > 0 {
 		for _, callBack := range producerBatch.callBackList {
 			callBack.Fail(producerBatch.result)


### PR DESCRIPTION
1.修复当batch 被投递到发送失败队列执行后不减少缓冲区内存的问题。