### PR TITLE
fix: fix data race in start and stop

### DIFF
--- a/consumer/worker_test.go
+++ b/consumer/worker_test.go
@@ -1,0 +1,33 @@
+package consumerLibrary
+
+import (
+	"fmt"
+	"testing"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+)
+
+func TestStartAndStop(t *testing.T) {
+	option := LogHubConfig{
+		Endpoint:          "",
+		AccessKeyID:       "",
+		AccessKeySecret:   "",
+		Project:           "",
+		Logstore:          "",
+		ConsumerGroupName: "",
+		ConsumerName:      "",
+		// This options is used for initialization, will be ignored once consumer group is created and each shard has been started to be consumed.
+		// Could be "begin", "end", "specific time format in time stamp", it's log receiving time.
+		CursorPosition: BEGIN_CURSOR,
+	}
+
+	worker := InitConsumerWorker(option, process)
+
+	worker.Start()
+	worker.StopAndWait()
+}
+
+func process(shardId int, logGroupList *sls.LogGroupList) string {
+	fmt.Printf("shardId %d processing works sucess", shardId)
+	return ""
+}


### PR DESCRIPTION
我需要动态关闭，然后重启worker，然后写了如提交中的测试用例，加上 -race 运行测试用例，会看到data race报错。

```
WARNING: DATA RACE
Write at 0x00c0002100b0 by goroutine 7:
  github.com/aliyun/aliyun-log-go-sdk/consumer.(*ConsumerWorker).StopAndWait()
      /go@1.13/workspace/pkg/mod/github.com/aliyun/aliyun-log-go-sdk@v0.1.12/consumer/worker.go:46 +0x234
```

这个是非原子操作导致的，需要修改为原子操作。也可以考虑引入uber的原子模块，不过本次先不引入了。