### PR TITLE
fix consumer arm32 issue

### DIFF
--- a/client_consumer.go
+++ b/client_consumer.go
@@ -23,7 +23,7 @@ type ConsumerGroup struct {
 type ConsumerGroupCheckPoint struct {
 	ShardID    int    `json:"shard"`
 	CheckPoint string `json:"checkpoint"`
-	UpdateTime int    `json:"updateTime"`
+	UpdateTime int64    `json:"updateTime"`
 	Consumer   string `json:"consumer"`
 }
 


### PR DESCRIPTION
指定int 类型，解决在arm 32位机器上运行时，int类型自动为32 位导致从服务端获取的 checkpoint time 无法json 反序列化问题。