### PR TITLE
fix producer callback function

### DIFF
--- a/producer/callback_test.go
+++ b/producer/callback_test.go
@@ -1,0 +1,74 @@
+package producer
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"testing"
+	"time"
+)
+
+
+
+type Callback struct {
+	t *testing.T
+}
+
+func (callback *Callback) Success(result *Result) {
+	attemptList := result.GetReservedAttempts()
+	for _, attempt := range attemptList {
+		fmt.Println(attempt)
+	}
+}
+
+func (callback *Callback) Fail(result *Result) {
+	if result.GetErrorMessage() == "" {
+		callback.t.Error("Failed to get error message")
+	}
+	if result.GetErrorCode() == "" {
+		callback.t.Error("Failed to get error code")
+	}
+
+	if len(result.GetReservedAttempts()) == 0 {
+		callback.t.Error("Failed to get error code")
+	}
+
+
+}
+
+func TestProducer_CallBack(t *testing.T) {
+	producerConfig := GetDefaultProducerConfig()
+	producerConfig.Endpoint = ""
+	producerConfig.AccessKeyID = ""
+	producerConfig.AccessKeySecret = ""
+	producerInstance := InitProducer(producerConfig)
+	ch := make(chan os.Signal)
+	signal.Notify(ch)
+	producerInstance.Start()
+	var m sync.WaitGroup
+	callBack := &Callback{}
+	for i := 0; i < 5; i++ {
+		m.Add(1)
+		go func() {
+			defer m.Done()
+			for i := 0; i < 10; i++ {
+				log := GenerateLog(uint32(time.Now().Unix()), map[string]string{"content": "test", "content2": fmt.Sprintf("%v", i)})
+				err := producerInstance.SendLogWithCallBack("project", "logstrore", "topic", "127.0.0.1", log, callBack)
+				if err != nil {
+					fmt.Println(err)
+				}
+			}
+		}()
+	}
+	m.Wait()
+	fmt.Println("Send completion")
+	if _, ok := <-ch; ok {
+		fmt.Println("Get the shutdown signal and start to shut down")
+		producerInstance.Close(60000)
+	}
+
+
+
+
+}


### PR DESCRIPTION
1. 修复producer 回调函数打印为空的问题。

该问题会由以下两种情况下出现：
 (1).  程序启动就错误，发送数据量非常少。因为producer异步发送，在消息未被发送时，已经接收到了retry关闭信号，这时候没有去给producerBatch 添加attemp 信息。
 (2). 遇到特定的错误码，没有给producerBatch 添加attemp 信息，例如 ProjectNotExist等 .