### PR TITLE
do not print debug information in non-test code

### DIFF
--- a/client_dashboard.go
+++ b/client_dashboard.go
@@ -295,7 +295,6 @@ func (c *Client) ListDashboardV2(project string, dashboardName string, offset, s
 	}
 
 	buf, _ := ioutil.ReadAll(r.Body)
-	fmt.Println(string(buf))
 	dashboards := &ListDashboardResponse{}
 	if err = json.Unmarshal(buf, dashboards); err != nil {
 		err = NewClientError(err)

--- a/client_etl.go
+++ b/client_etl.go
@@ -205,7 +205,6 @@ func (c *Client) StopETL(project, name string) error {
 	}
 
 	uri := fmt.Sprintf("/jobs/%s?action=STOP", name)
-	fmt.Println(uri)
 	r, err := c.request(project, "PUT", uri, h, nil)
 	if err != nil {
 		return err

--- a/log_store_shiper.go
+++ b/log_store_shiper.go
@@ -103,8 +103,6 @@ func (s *LogStore) ListShipper() ([]string, error) {
 	defer r.Body.Close()
 
 	buf, err := ioutil.ReadAll(r.Body)
-	body1 := string(buf)
-	fmt.Println(body1)
 
 	if r.StatusCode != http.StatusOK {
 		err := new(Error)


### PR DESCRIPTION
I’m integrating this SDK into my software and find that some debug information is printed to stdout when I call normal methods, e.g.

- LogStore.ListShipper() 

I think this is not necessary and I send this PR to remove them.