### PR TITLE
Extract request-id for GetLogs and GetHistogram

### DIFF
--- a/log_store.go
+++ b/log_store.go
@@ -499,7 +499,7 @@ func (s *LogStore) GetHistograms(topic string, from int64, to int64, queryExp st
 		return nil, err
 	}
 
-	histograms := []SingleHistogram{}
+	var histograms []SingleHistogram
 	err = json.Unmarshal(body, &histograms)
 	if err != nil {
 		return nil, NewBadResponseError(string(body), r.Header, r.StatusCode)
@@ -510,6 +510,9 @@ func (s *LogStore) GetHistograms(topic string, from int64, to int64, queryExp st
 		return nil, err
 	}
 	getHistogramsResponse := GetHistogramsResponse{
+		MetaResponse: MetaResponse{
+			RequestId: r.Header.Get(RequestIDHeader),
+		},
 		Progress:   r.Header[ProgressHeader][0],
 		Count:      count,
 		Histograms: histograms,

--- a/log_store.go
+++ b/log_store.go
@@ -570,7 +570,7 @@ func (s *LogStore) getLogs(topic string, from int64, to int64, queryExp string,
 
 	return r, body, &GetLogsResponse{
 		MetaResponse: MetaResponse{
-			RequestId: r.Header[RequestIDHeader][0],
+			RequestId: r.Header.Get(RequestIDHeader),
 		},
 		Progress: r.Header[ProgressHeader][0],
 		Count:    count,

--- a/log_store.go
+++ b/log_store.go
@@ -358,7 +358,7 @@ func (s *LogStore) GetCursor(shardID int, from string) (cursor string, err error
 
 // GetLogsBytes gets logs binary data from shard specified by shardId according cursor and endCursor.
 // The logGroupMaxCount is the max number of logGroup could be returned.
-// The nextCursor is the next curosr can be used to read logs at next time.
+// The nextCursor is the next cursor can be used to read logs at next time.
 func (s *LogStore) GetLogsBytes(shardID int, cursor, endCursor string,
 	logGroupMaxCount int) (out []byte, nextCursor string, err error) {
 	h := map[string]string{
@@ -569,6 +569,9 @@ func (s *LogStore) getLogs(topic string, from int64, to int64, queryExp string,
 	}
 
 	return r, body, &GetLogsResponse{
+		MetaResponse: MetaResponse{
+			RequestId: r.Header[RequestIDHeader][0],
+		},
 		Progress: r.Header[ProgressHeader][0],
 		Count:    count,
 		Contents: contents,
@@ -604,7 +607,7 @@ func (s *LogStore) GetLogs(topic string, from int64, to int64, queryExp string,
 
 	rsp, b, logRsp, err := s.getLogs(topic, from, to, queryExp, maxLineNum, offset, reverse)
 	if err == nil && len(b) != 0 {
-		logs := []map[string]string{}
+		var logs []map[string]string
 		err = json.Unmarshal(b, &logs)
 		if err != nil {
 			return nil, NewBadResponseError(string(b), rsp.Header, rsp.StatusCode)

--- a/model.go
+++ b/model.go
@@ -14,6 +14,7 @@ type SingleHistogram struct {
 }
 
 type GetHistogramsResponse struct {
+	MetaResponse
 	Progress   string            `json:"progress"`
 	Count      int64             `json:"count"`
 	Histograms []SingleHistogram `json:"histograms"`

--- a/model.go
+++ b/model.go
@@ -23,8 +23,15 @@ func (resp *GetHistogramsResponse) IsComplete() bool {
 	return strings.ToLower(resp.Progress) == "complete"
 }
 
+// MetaResponse defines common response for all SLS APIs,
+// as is documented https://help.aliyun.com/document_detail/29011.html
+type MetaResponse struct {
+	RequestId string
+}
+
 // GetLogsResponse defines response from GetLogs call
 type GetLogsResponse struct {
+	MetaResponse
 	Progress string              `json:"progress"`
 	Count    int64               `json:"count"`
 	Logs     []map[string]string `json:"logs"`
@@ -36,7 +43,7 @@ type GetLogsResponse struct {
 // note: GetLogLinesResponse.Logs is nil when use GetLogLinesResponse
 type GetLogLinesResponse struct {
 	GetLogsResponse
-	Lines     []json.RawMessage
+	Lines []json.RawMessage
 }
 
 func (resp *GetLogsResponse) IsComplete() bool {


### PR DESCRIPTION
In order to help identify some issues, e.g. long latency with `GetLogs` or `GetHistogram`, I have added `MetaResponse` which contains `RequestId` given in the http response headers.