### PR TITLE
[bugfix] fix dead lock since golang doesn't support ReentrantLock

### DIFF
--- a/client.go
+++ b/client.go
@@ -95,6 +95,10 @@ type Client struct {
 func convert(c *Client, projName string) *LogProject {
 	c.accessKeyLock.RLock()
 	defer c.accessKeyLock.RUnlock()
+	return convertLogProject(c, projName)
+}
+
+func convertLogProject(c *Client, projName string) *LogProject {
 	p, _ := NewLogProject(projName, c.Endpoint, c.AccessKeyID, c.AccessKeySecret)
 	p.SecurityToken = c.SecurityToken
 	p.UserAgent = c.UserAgent

--- a/client.go
+++ b/client.go
@@ -95,10 +95,10 @@ type Client struct {
 func convert(c *Client, projName string) *LogProject {
 	c.accessKeyLock.RLock()
 	defer c.accessKeyLock.RUnlock()
-	return convertLogProject(c, projName)
+	return convertLocked(c, projName)
 }
 
-func convertLogProject(c *Client, projName string) *LogProject {
+func convertLocked(c *Client, projName string) *LogProject {
 	p, _ := NewLogProject(projName, c.Endpoint, c.AccessKeyID, c.AccessKeySecret)
 	p.SecurityToken = c.SecurityToken
 	p.UserAgent = c.UserAgent

--- a/client_store.go
+++ b/client_store.go
@@ -16,7 +16,7 @@ import (
 
 func convertLogstore(c *Client, project, logstore string) *LogStore {
 	c.accessKeyLock.RLock()
-	proj := convert(c, project)
+	proj := convertLogProject(c, project)
 	c.accessKeyLock.RUnlock()
 	return &LogStore{
 		project: proj,

--- a/client_store.go
+++ b/client_store.go
@@ -16,7 +16,7 @@ import (
 
 func convertLogstore(c *Client, project, logstore string) *LogStore {
 	c.accessKeyLock.RLock()
-	proj := convertLogProject(c, project)
+	proj := convertLocked(c, project)
 	c.accessKeyLock.RUnlock()
 	return &LogStore{
 		project: proj,


### PR DESCRIPTION
Hi there, when we create a sls client by using `CreateTokenAutoUpdateClient` and use this client to PutLogs, there probably happens a dead lock and the program will hang. The `convertLogstore` func uses RLock, and `convert` func uses RLock again, in this interval if the `ResetAccessKeyToken` func WLock wants to get the lock, there will get a dead lock panic, so we should remove the `ReentrantLock` in golang sdk.