### PR TITLE
consumer support SecurityToken

### DIFF
--- a/consumer/config.go
+++ b/consumer/config.go
@@ -54,7 +54,7 @@ type LogHubConfig struct {
 	LogMaxBackups             int
 	LogCompass                bool
 	HTTPClient                *http.Client
-	// SecurityToken        string
+	SecurityToken             string
 }
 
 const (

--- a/consumer/consumer_client.go
+++ b/consumer/consumer_client.go
@@ -30,7 +30,7 @@ func initConsumerClient(option LogHubConfig, logger log.Logger) *ConsumerClient 
 		Endpoint:        option.Endpoint,
 		AccessKeyID:     option.AccessKeyID,
 		AccessKeySecret: option.AccessKeySecret,
-		// SecurityToken:   option.SecurityToken,
+		SecurityToken:   option.SecurityToken,
 		UserAgent: option.ConsumerGroupName + "_" + option.ConsumerName,
 	}
 	if option.HTTPClient != nil {


### PR DESCRIPTION
我们在删除这个字段前就已经在用这个字段了，迁移到go mod后发现突然没了，导致编译不过，需要恢复这个字段