### PR TITLE
Support custome client

### DIFF
--- a/consumer/consumer_client.go
+++ b/consumer/consumer_client.go
@@ -15,7 +15,7 @@ type ConsumerClient struct {
 	logger        log.Logger
 }
 
-func initConsumerClient(option LogHubConfig, logger log.Logger) *ConsumerClient {
+func initConsumerClient(client *sls.Client, option LogHubConfig, logger log.Logger) *ConsumerClient {
 	// Setting configuration defaults
 	if option.HeartbeatIntervalInSecond == 0 {
 		option.HeartbeatIntervalInSecond = 20
@@ -26,12 +26,14 @@ func initConsumerClient(option LogHubConfig, logger log.Logger) *ConsumerClient 
 	if option.MaxFetchLogGroupCount == 0 {
 		option.MaxFetchLogGroupCount = 1000
 	}
-	client := &sls.Client{
-		Endpoint:        option.Endpoint,
-		AccessKeyID:     option.AccessKeyID,
-		AccessKeySecret: option.AccessKeySecret,
-		SecurityToken:   option.SecurityToken,
-		UserAgent: option.ConsumerGroupName + "_" + option.ConsumerName,
+	if client == nil {
+		client = &sls.Client{
+			Endpoint:        option.Endpoint,
+			AccessKeyID:     option.AccessKeyID,
+			AccessKeySecret: option.AccessKeySecret,
+			SecurityToken:   option.SecurityToken,
+			UserAgent:       option.ConsumerGroupName + "_" + option.ConsumerName,
+		}
 	}
 	if option.HTTPClient != nil {
 		client.SetHTTPClient(option.HTTPClient)

--- a/consumer/worker.go
+++ b/consumer/worker.go
@@ -23,8 +23,17 @@ type ConsumerWorker struct {
 }
 
 func InitConsumerWorker(option LogHubConfig, do func(int, *sls.LogGroupList) string) *ConsumerWorker {
+	return initConsumerWorker(nil, option, do)
+}
+
+// InitConsumerWorkerWithClient Support custome client
+func InitConsumerWorkerWithClient(client *sls.Client, option LogHubConfig, do func(int, *sls.LogGroupList) string) *ConsumerWorker {
+	return initConsumerWorker(client, option, do)
+}
+
+func initConsumerWorker(client *sls.Client, option LogHubConfig, do func(int, *sls.LogGroupList) string) *ConsumerWorker {
 	logger := logConfig(option)
-	consumerClient := initConsumerClient(option, logger)
+	consumerClient := initConsumerClient(client, option, logger)
 	consumerHeatBeat := initConsumerHeatBeat(consumerClient, logger)
 	consumerWorker := &ConsumerWorker{
 		consumerHeatBeat:   consumerHeatBeat,

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -30,15 +30,25 @@ type Producer struct {
 }
 
 func InitProducer(producerConfig *ProducerConfig) *Producer {
-	logger := logConfig(producerConfig)
+	return initProducer(nil, producerConfig)
+}
 
-	client := sls.CreateNormalInterface(producerConfig.Endpoint, producerConfig.AccessKeyID, producerConfig.AccessKeySecret, "")
-	if producerConfig.UpdateStsToken != nil && producerConfig.StsTokenShutDown != nil {
-		stsClient, err := sls.CreateTokenAutoUpdateClient(producerConfig.Endpoint, producerConfig.UpdateStsToken, producerConfig.StsTokenShutDown)
-		if err != nil {
-			level.Warn(logger).Log("msg", "Failed to create ststoken client, use default client without ststoken.", "error", err)
-		} else {
-			client = stsClient
+// InitProducerWithClient Support custome client
+func InitProducerWithClient(client sls.ClientInterface, producerConfig *ProducerConfig) *Producer {
+	return initProducer(client, producerConfig)
+}
+
+func initProducer(client sls.ClientInterface, producerConfig *ProducerConfig) *Producer {
+	logger := logConfig(producerConfig)
+	if client == nil {
+		client = sls.CreateNormalInterface(producerConfig.Endpoint, producerConfig.AccessKeyID, producerConfig.AccessKeySecret, "")
+		if producerConfig.UpdateStsToken != nil && producerConfig.StsTokenShutDown != nil {
+			stsClient, err := sls.CreateTokenAutoUpdateClient(producerConfig.Endpoint, producerConfig.UpdateStsToken, producerConfig.StsTokenShutDown)
+			if err != nil {
+				level.Warn(logger).Log("msg", "Failed to create ststoken client, use default client without ststoken.", "error", err)
+			} else {
+				client = stsClient
+			}
 		}
 	}
 	if producerConfig.HTTPClient != nil {


### PR DESCRIPTION
我使用Vault管理阿里云STS token，并利用Vault Agent作为k8s pod的sidecar自动轮转STS token。但是，在业务容器中，无法确定token的expireTime，因此无法利用`AutoUpdateClient`。我在业务里面实现STS token轮转时自动更新 sls.Client对象中的STS token，但是使用标准库的Comsumer和Producer组件时，不支持自定义Client。