### PR TITLE
Bump go-kit to 11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58
 	github.com/frankban/quicktest v1.10.2 // indirect
-	github.com/go-kit/kit v0.10.0
+	github.com/go-kit/kit v0.11.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.4.2
 	github.com/pierrec/lz4 v2.6.0+incompatible


### PR DESCRIPTION
When running go mod tidy, I am seeing the error below. I am submitting this PR to bump the version which resolves the issue. The link https://sourcegraph.com/sourcegraph/appdash?go-get=1 does return a 404.

**Error**
go: [github.com/aliyun/aliyun-log-go-sdk@v0.1.66](http://github.com/aliyun/aliyun-log-go-sdk@v0.1.66) requires
	[github.com/go-kit/kit@v0.10.0](http://github.com/go-kit/kit@v0.10.0) requires
	[sourcegraph.com/sourcegraph/appdash@v0.0.0-20190731080439-ebfcffb1b5c0](http://sourcegraph.com/sourcegraph/appdash@v0.0.0-20190731080439-ebfcffb1b5c0): unrecognized import path "[sourcegraph.com/sourcegraph/appdash](http://sourcegraph.com/sourcegraph/appdash)": reading https://sourcegraph.com/sourcegraph/appdash?go-get=1: 404 Not Found
	
**Downstream Project**
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsxrayexporter/go.mod