### PR TITLE
GetDefaultProducerConfig  默认值 DisableRuntimeMetrics:true

### DIFF
--- a/producer/producer_config.go
+++ b/producer/producer_config.go
@@ -94,5 +94,6 @@ func GetDefaultProducerConfig() *ProducerConfig {
 		MaxBatchCount:         4096,
 		NoRetryStatusCodeList: []int{400, 404},
 		CompressType:          sls.Compress_LZ4,
+		DisableRuntimeMetrics: true,
 	}
 }


### PR DESCRIPTION
DisableRuntimeMetrics 影响日志打印,默认需要开启