### PR TITLE
docs: add Chinese README cross-link to README_EN.md

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -1,3 +1,5 @@
+[中文版 README](https://github.com/aliyun/aliyun-log-go-sdk/blob/master/README.md)
+
 This is a Golang SDK for Alibaba Cloud [Log Service](https://sls.console.aliyun.com/).
 
 API Reference :


### PR DESCRIPTION
## Summary

`README.md` already provides a link to `README_EN.md` for English readers, but `README_EN.md` did not link back to the Chinese version. This PR adds a brief cross-link header to `README_EN.md` so navigation works in both directions.

Diff is a single 2-line addition at the top of `README_EN.md`.

## Why

Readers landing directly on the English README (e.g., from search results) currently have no obvious path back to the Chinese README, which still has slightly different coverage (consumer/producer section indices, etc.).

## Test plan

- [x] `README_EN.md` renders the new link at the top
- [x] Link target resolves to `README.md` on `master`