### PR TITLE
feat(producer): raise MaxBatchSize upper limit from 5MB to 20MB

### DIFF
--- a/producer/producer.go
+++ b/producer/producer.go
@@ -124,7 +124,10 @@ func validateProducerConfig(producerConfig *ProducerConfig, logger log.Logger) *
 		level.Warn(logger).Log("msg", "The parameter MaxBatchCount exceeds the set maximum and has been reset to the set maximum of 40960.")
 		producerConfig.MaxBatchCount = 40960
 	}
-	if producerConfig.MaxBatchSize > 1024*1024*20 || producerConfig.MaxBatchSize <= 0 {
+	if producerConfig.MaxBatchSize <= 0 {
+		level.Warn(logger).Log("msg", "The parameter MaxBatchSize must be greater than zero, reset to default 5M.")
+		producerConfig.MaxBatchSize = 1024 * 1024 * 5
+	} else if producerConfig.MaxBatchSize > 1024*1024*20 {
 		level.Warn(logger).Log("msg", "The parameter MaxBatchSize exceeds the settable maximum and has reset a single logGroup memory size of up to 20M.")
 		producerConfig.MaxBatchSize = 1024 * 1024 * 20
 	}

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -124,9 +124,9 @@ func validateProducerConfig(producerConfig *ProducerConfig, logger log.Logger) *
 		level.Warn(logger).Log("msg", "The parameter MaxBatchCount exceeds the set maximum and has been reset to the set maximum of 40960.")
 		producerConfig.MaxBatchCount = 40960
 	}
-	if producerConfig.MaxBatchSize > 1024*1024*5 || producerConfig.MaxBatchSize <= 0 {
-		level.Warn(logger).Log("msg", "The parameter MaxBatchSize exceeds the settable maximum and has reset a single logGroup memory size of up to 5M.")
-		producerConfig.MaxBatchSize = 1024 * 1024 * 5
+	if producerConfig.MaxBatchSize > 1024*1024*20 || producerConfig.MaxBatchSize <= 0 {
+		level.Warn(logger).Log("msg", "The parameter MaxBatchSize exceeds the settable maximum and has reset a single logGroup memory size of up to 20M.")
+		producerConfig.MaxBatchSize = 1024 * 1024 * 20
 	}
 	if producerConfig.MaxIoWorkerCount <= 0 {
 		level.Warn(logger).Log("msg", "The MaxIoWorkerCount parameter cannot be less than zero and has been reset to the default value of 50")

--- a/producer/producer_config_test.go
+++ b/producer/producer_config_test.go
@@ -1,0 +1,46 @@
+package producer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestValidateMaxBatchSize(t *testing.T) {
+	logger := log.NewLogfmtLogger(os.Stderr)
+
+	tests := []struct {
+		name     string
+		input    int64
+		expected int64
+	}{
+		{"negative resets to 5MB", -1, 1024 * 1024 * 5},
+		{"zero resets to 5MB", 0, 1024 * 1024 * 5},
+		{"valid small value kept", 1024, 1024},
+		{"5MB kept", 1024 * 1024 * 5, 1024 * 1024 * 5},
+		{"10MB kept", 1024 * 1024 * 10, 1024 * 1024 * 10},
+		{"20MB kept", 1024 * 1024 * 20, 1024 * 1024 * 20},
+		{"over 20MB clamped to 20MB", 1024*1024*20 + 1, 1024 * 1024 * 20},
+		{"50MB clamped to 20MB", 1024 * 1024 * 50, 1024 * 1024 * 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := GetDefaultProducerConfig()
+			config.MaxBatchSize = tt.input
+			validated := validateProducerConfig(config, logger)
+			if validated.MaxBatchSize != tt.expected {
+				t.Errorf("MaxBatchSize = %d, want %d", validated.MaxBatchSize, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultMaxBatchSize(t *testing.T) {
+	config := GetDefaultProducerConfig()
+	expected := int64(512 * 1024)
+	if config.MaxBatchSize != expected {
+		t.Errorf("default MaxBatchSize = %d, want %d", config.MaxBatchSize, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Raise the `MaxBatchSize` configurable upper limit from 5MB to 20MB in producer validation logic
- Default value (512KB) remains unchanged — users can now set `MaxBatchSize` up to 20MB to support larger single log entries and batch packages

## Test plan
- [x] Verify default `MaxBatchSize` is still 512KB via `GetDefaultProducerConfig()`
- [x] Verify setting `MaxBatchSize` to 10MB (within new limit) is accepted without clamping
- [x] Verify setting `MaxBatchSize` to 25MB (over new limit) is clamped to 20MB with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)