### PR TITLE
ci: add manual release workflow for Go tag publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag version (e.g. v0.4.0)'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag format
+        run: |
+          if [[ ! "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Tag must match vX.Y.Z or vX.Y.Z-pre format"
+            exit 1
+          fi
+
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse "refs/tags/${{ inputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.tag }} already exists"
+            exit 1
+          fi
+
+      - name: Create tag
+        run: |
+          git tag "${{ inputs.tag }}"
+          git push origin "${{ inputs.tag }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${{ inputs.tag }}" --generate-notes


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` — manual-only workflow for publishing Go module tags and GitHub Releases
- Restricted to `master` branch, triggered via `workflow_dispatch` with a `tag` input (e.g. `v0.4.0`)
- Validates tag format (`vX.Y.Z` / `vX.Y.Z-pre`), checks tag doesn't already exist, creates the tag, and publishes a GitHub Release with auto-generated release notes

## Test plan
- [ ] Navigate to Actions → Release → Run workflow, verify it only appears on `master`
- [ ] Run with a valid tag (e.g. `v0.4.1`), confirm tag and release are created
- [ ] Run with an invalid tag (e.g. `abc`), confirm it fails at validation
- [ ] Run with a duplicate tag, confirm it fails with "already exists" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)