### PR TITLE
feat(producer): raise MaxBatchSize upper limit from 20MB to 30MB

### DIFF
--- a/producer/producer.go
+++ b/producer/producer.go
@@ -127,9 +127,9 @@ func validateProducerConfig(producerConfig *ProducerConfig, logger log.Logger) *
 	if producerConfig.MaxBatchSize <= 0 {
 		level.Warn(logger).Log("msg", "The parameter MaxBatchSize must be greater than zero, reset to default 5M.")
 		producerConfig.MaxBatchSize = 1024 * 1024 * 5
-	} else if producerConfig.MaxBatchSize > 1024*1024*20 {
-		level.Warn(logger).Log("msg", "The parameter MaxBatchSize exceeds the settable maximum and has reset a single logGroup memory size of up to 20M.")
-		producerConfig.MaxBatchSize = 1024 * 1024 * 20
+	} else if producerConfig.MaxBatchSize > 1024*1024*30 {
+		level.Warn(logger).Log("msg", "The parameter MaxBatchSize exceeds the settable maximum and has reset a single logGroup memory size of up to 30M.")
+		producerConfig.MaxBatchSize = 1024 * 1024 * 30
 	}
 	if producerConfig.MaxIoWorkerCount <= 0 {
 		level.Warn(logger).Log("msg", "The MaxIoWorkerCount parameter cannot be less than zero and has been reset to the default value of 50")

--- a/producer/producer_config_test.go
+++ b/producer/producer_config_test.go
@@ -21,8 +21,9 @@ func TestValidateMaxBatchSize(t *testing.T) {
 		{"5MB kept", 1024 * 1024 * 5, 1024 * 1024 * 5},
 		{"10MB kept", 1024 * 1024 * 10, 1024 * 1024 * 10},
 		{"20MB kept", 1024 * 1024 * 20, 1024 * 1024 * 20},
-		{"over 20MB clamped to 20MB", 1024*1024*20 + 1, 1024 * 1024 * 20},
-		{"50MB clamped to 20MB", 1024 * 1024 * 50, 1024 * 1024 * 20},
+		{"30MB kept", 1024 * 1024 * 30, 1024 * 1024 * 30},
+		{"over 30MB clamped to 30MB", 1024*1024*30 + 1, 1024 * 1024 * 30},
+		{"50MB clamped to 30MB", 1024 * 1024 * 50, 1024 * 1024 * 30},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Raise the `MaxBatchSize` configurable upper limit from 20MB to 30MB
- Default value (512KB) and `<=0` fallback (5MB) remain unchanged
- Updated unit tests to cover the new 30MB boundary

## Test plan
- [x] Unit tests pass (`TestValidateMaxBatchSize`, `TestDefaultMaxBatchSize`)
- [ ] Verify setting `MaxBatchSize` to 25MB is accepted without clamping
- [ ] Verify setting `MaxBatchSize` to 35MB is clamped to 30MB with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)