### PR TITLE
[codex] Pass nil hash table to lz4 CompressBlock

### DIFF
--- a/log_store.go
+++ b/log_store.go
@@ -156,8 +156,7 @@ func (s *LogStore) PutRawLog(rawLogData []byte) (err error) {
 	case Compress_LZ4:
 		// Compresse body with lz4
 		out = make([]byte, lz4.CompressBlockBound(len(rawLogData)))
-		var hashTable [1 << 16]int
-		n, err := lz4.CompressBlock(rawLogData, out, hashTable[:])
+		n, err := lz4.CompressBlock(rawLogData, out, nil)
 		if err != nil {
 			return NewClientError(err)
 		}
@@ -228,8 +227,7 @@ func (s *LogStore) PostRawLogs(body []byte, hashKey *string) (err error) {
 	case Compress_LZ4:
 		// Compresse body with lz4
 		out = make([]byte, lz4.CompressBlockBound(len(body)))
-		var hashTable [1 << 16]int
-		n, err := lz4.CompressBlock(body, out, hashTable[:])
+		n, err := lz4.CompressBlock(body, out, nil)
 		if err != nil {
 			return NewClientError(err)
 		}
@@ -303,8 +301,7 @@ func (s *LogStore) PutLogs(lg *LogGroup) (err error) {
 	case Compress_LZ4:
 		// Compresse body with lz4
 		out = make([]byte, lz4.CompressBlockBound(len(body)))
-		var hashTable [1 << 16]int
-		n, err := lz4.CompressBlock(body, out, hashTable[:])
+		n, err := lz4.CompressBlock(body, out, nil)
 		if err != nil {
 			return NewClientError(err)
 		}
@@ -390,8 +387,7 @@ func (s *LogStore) PostLogStoreLogs(req *PostLogStoreLogsRequest) (err error) {
 	case Compress_LZ4:
 		// Compresse body with lz4
 		out = make([]byte, lz4.CompressBlockBound(len(body)))
-		var hashTable [1 << 16]int
-		n, err := lz4.CompressBlock(body, out, hashTable[:])
+		n, err := lz4.CompressBlock(body, out, nil)
 		if err != nil {
 			return NewClientError(err)
 		}

--- a/logstore_mock_test.go
+++ b/logstore_mock_test.go
@@ -120,9 +120,8 @@ func TestLogStoreWriteErrorMock(t *testing.T) {
 	body, _ := proto.Marshal(lg)
 
 	// Compresse body with lz4
-	var hashTable [1 << 16]int
 	out := make([]byte, lz4.CompressBlockBound(len(body)))
-	n, _ := lz4.CompressBlock(body, out, hashTable[:])
+	n, _ := lz4.CompressBlock(body, out, nil)
 
 	h := map[string]string{
 		"x-log-compresstype": "lz4",

--- a/lz4_compression_test.go
+++ b/lz4_compression_test.go
@@ -1,0 +1,72 @@
+package sls
+
+import (
+	"bytes"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/pierrec/lz4/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLZ4CompressBlockNilRoundTrip(t *testing.T) {
+	cases := map[string][]byte{
+		"compressible": bytes.Repeat([]byte("aliyun-log-service-"), 256),
+		"mixed":        deterministicBytes(32 * 1024),
+	}
+
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			dst := make([]byte, lz4.CompressBlockBound(len(src)))
+			n, err := lz4.CompressBlock(src, dst, nil)
+			require.NoError(t, err)
+			require.NotZero(t, n)
+
+			got, err := decompressLZ4ForTest(len(src), dst[:n])
+			require.NoError(t, err)
+			require.Equal(t, src, got)
+		})
+	}
+}
+
+func TestLZ4CopyIncompressibleRoundTrip(t *testing.T) {
+	src := deterministicBytes(64 * 1024)
+	dst := make([]byte, lz4.CompressBlockBound(len(src)))
+
+	n, err := copyIncompressible(src, dst)
+	require.NoError(t, err)
+	require.NotZero(t, n)
+
+	got, err := decompressLZ4ForTest(len(src), dst[:n])
+	require.NoError(t, err)
+	require.Equal(t, src, got)
+}
+
+func TestLZ4DecompressResponseRejectsSizeMismatch(t *testing.T) {
+	src := bytes.Repeat([]byte("log-data-"), 128)
+	dst := make([]byte, lz4.CompressBlockBound(len(src)))
+	n, err := lz4.CompressBlock(src, dst, nil)
+	require.NoError(t, err)
+	require.NotZero(t, n)
+
+	_, err = decompressLZ4ForTest(len(src)+1, dst[:n])
+	require.ErrorContains(t, err, "does not match")
+}
+
+func decompressLZ4ForTest(rawSize int, body []byte) ([]byte, error) {
+	return decompressResponse(rawSize, body, &http.Response{
+		Header: http.Header{
+			"X-Log-Compresstype": []string{"lz4"},
+			"X-Log-Bodyrawsize":  []string{strconv.Itoa(rawSize)},
+		},
+	})
+}
+
+func deterministicBytes(n int) []byte {
+	out := make([]byte, n)
+	r := rand.New(rand.NewSource(1))
+	_, _ = r.Read(out)
+	return out
+}


### PR DESCRIPTION
## Summary
- remove explicit hashTable allocation from lz4 CompressBlock calls
- pass nil for the deprecated ignored hash table argument
- add dedicated lz4 compression/decompression unit tests for normal block compression, incompressible block fallback, and raw-size mismatch handling

## Validation
- CGO_ENABLED=0 go test . ./consumer ./producer ./util
- CGO_CFLAGS='-g0' go test . -run 'TestLZ4'\n- CGO_CFLAGS='-g0' go test ./...\n\nNote: plain go test ./... fails in this local environment while building runtime/cgo because GCC 10 emits DWARF/location-view assembler directives that the local GNU as 2.27 does not understand.