### PR TITLE
[codex] Add DescribeRegions API

### DIFF
--- a/client_interface.go
+++ b/client_interface.go
@@ -95,6 +95,8 @@ type ClientInterface interface {
 	SetAuthVersion(version AuthVersionType)
 	// Close the client
 	Close() error
+	// DescribeRegions queries available Log Service regions.
+	DescribeRegions(req *DescribeRegionsRequest) (*DescribeRegionsResponse, error)
 
 	// #################### Project Operations #####################
 	// CreateProject create a new loghub project.

--- a/client_region.go
+++ b/client_region.go
@@ -1,0 +1,63 @@
+package sls
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type DescribeRegionsRequest struct {
+	// Language specifies the localized region name language, such as zh, en, or jp.
+	Language string `json:"language,omitempty"`
+}
+
+type RegionInfo struct {
+	Region              string   `json:"region"`
+	LocalName           string   `json:"localName"`
+	IntranetEndpoint    string   `json:"intranetEndpoint"`
+	InternetEndpoint    string   `json:"internetEndpoint"`
+	InternalEndpoint    string   `json:"internalEndpoint"`
+	DataRedundancyTypes []string `json:"dataRedundancyType"`
+}
+
+type DescribeRegionsResponse struct {
+	Regions []RegionInfo `json:"regions"`
+}
+
+func (c *Client) DescribeRegions(req *DescribeRegionsRequest) (*DescribeRegionsResponse, error) {
+	h := map[string]string{
+		"x-log-bodyrawsize": "0",
+		"Content-Type":      "application/json",
+	}
+
+	urlVal := url.Values{}
+	if req != nil && req.Language != "" {
+		urlVal.Add("language", req.Language)
+	}
+
+	uri := "/regions"
+	if len(urlVal) > 0 {
+		uri += "?" + urlVal.Encode()
+	}
+
+	r, err := c.request("", "GET", uri, h, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, readResponseError(err)
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, httpStatusNotOkError(buf, r.Header, r.StatusCode)
+	}
+
+	resp := &DescribeRegionsResponse{}
+	if err := json.Unmarshal(buf, resp); err != nil {
+		return nil, NewClientError(err)
+	}
+	return resp, nil
+}

--- a/client_region_test.go
+++ b/client_region_test.go
@@ -1,0 +1,58 @@
+package sls
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeRegions(t *testing.T) {
+	const endpoint = "mock-test-endpoint.aliyuncs.com"
+	client := CreateNormalInterface(endpoint, "testAccessKeyId", "testAccessKeySecret", "").(*Client)
+	transport := httpmock.NewMockTransport()
+	client.SetHTTPClient(&http.Client{Transport: transport})
+
+	transport.RegisterResponder("GET", "http://"+endpoint+"/regions?language=zh",
+		func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "0", req.Header.Get("x-log-bodyrawsize"))
+			require.Equal(t, endpoint, req.Host)
+			return httpmock.NewStringResponse(200, `{
+				"regions": [
+					{
+						"region": "cn-hangzhou",
+						"localName": "Hangzhou",
+						"intranetEndpoint": "cn-hangzhou-intranet.log.aliyuncs.com",
+						"internetEndpoint": "cn-hangzhou.log.aliyuncs.com",
+						"internalEndpoint": "cn-hangzhou-internal.log.aliyuncs.com",
+						"dataRedundancyType": ["LRS", "ZRS"]
+					}
+				]
+			}`), nil
+		})
+
+	resp, err := client.DescribeRegions(&DescribeRegionsRequest{Language: "zh"})
+	require.NoError(t, err)
+	require.Len(t, resp.Regions, 1)
+	require.Equal(t, "cn-hangzhou", resp.Regions[0].Region)
+	require.Equal(t, "Hangzhou", resp.Regions[0].LocalName)
+	require.Equal(t, "cn-hangzhou-intranet.log.aliyuncs.com", resp.Regions[0].IntranetEndpoint)
+	require.Equal(t, "cn-hangzhou.log.aliyuncs.com", resp.Regions[0].InternetEndpoint)
+	require.Equal(t, "cn-hangzhou-internal.log.aliyuncs.com", resp.Regions[0].InternalEndpoint)
+	require.Equal(t, []string{"LRS", "ZRS"}, resp.Regions[0].DataRedundancyTypes)
+}
+
+func TestDescribeRegionsWithoutLanguage(t *testing.T) {
+	const endpoint = "mock-test-endpoint.aliyuncs.com"
+	client := CreateNormalInterface(endpoint, "testAccessKeyId", "testAccessKeySecret", "").(*Client)
+	transport := httpmock.NewMockTransport()
+	client.SetHTTPClient(&http.Client{Transport: transport})
+
+	transport.RegisterResponder("GET", "http://"+endpoint+"/regions",
+		httpmock.NewStringResponder(200, `{"regions":[]}`))
+
+	resp, err := client.DescribeRegions(nil)
+	require.NoError(t, err)
+	require.Empty(t, resp.Regions)
+}

--- a/token_auto_update_client.go
+++ b/token_auto_update_client.go
@@ -170,6 +170,16 @@ func (c *TokenAutoUpdateClient) ResetAccessKeyToken(accessKeyID, accessKeySecret
 	c.logClient.ResetAccessKeyToken(accessKeyID, accessKeySecret, securityToken)
 }
 
+func (c *TokenAutoUpdateClient) DescribeRegions(req *DescribeRegionsRequest) (resp *DescribeRegionsResponse, err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		resp, err = c.logClient.DescribeRegions(req)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}
+
 func (c *TokenAutoUpdateClient) CreateProject(name, description string) (prj *LogProject, err error) {
 	for i := 0; i < c.maxTryTimes; i++ {
 		prj, err = c.logClient.CreateProject(name, description)


### PR DESCRIPTION
## Summary
- Add DescribeRegions request and response models.
- Implement GET /regions with optional language query support.
- Add ClientInterface and TokenAutoUpdateClient coverage.
- Add mock tests for requests with and without language.

## Validation
- CGO_ENABLED=0 go test . -run 'TestDescribeRegions'