### PR TITLE
[codex] Document ListAllProjects availability

### DIFF
--- a/client.go
+++ b/client.go
@@ -410,8 +410,10 @@ func (c *Client) ListProjectV3(req *ListProjectRequest) (projects []LogProject, 
 	return body.Projects, body.Count, body.Total, err
 }
 
-// ListAllProjects list all projects with type=all parameter
-// ref https://help.aliyun.com/document_detail/xxxxx.htm
+// ListAllProjects lists projects across all regions.
+// This API is currently available only in supported regions, such as
+// cn-shanghai and ap-southeast-1. It is used to retrieve projects from all
+// regions.
 func (c *Client) ListAllProjects(req *ListAllProjectsRequest) (resp *ListAllProjectsResponse, err error) {
 	h := map[string]string{
 		"x-log-bodyrawsize": "0",
@@ -419,23 +421,25 @@ func (c *Client) ListAllProjects(req *ListAllProjectsRequest) (resp *ListAllProj
 
 	urlVal := url.Values{}
 	urlVal.Add("type", "all")
-	if req.Offset > 0 {
-		urlVal.Add("offset", strconv.Itoa(req.Offset))
-	}
-	if req.Size > 0 {
-		urlVal.Add("size", strconv.Itoa(req.Size))
-	}
-	if req.RegionId != "" {
-		urlVal.Add("regionId", req.RegionId)
-	}
-	if req.ProjectName != "" {
-		urlVal.Add("projectName", req.ProjectName)
-	}
-	if req.ResourceGroupId != "" {
-		urlVal.Add("resourceGroupId", req.ResourceGroupId)
-	}
-	if req.SearchText != "" {
-		urlVal.Add("searchText", req.SearchText)
+	if req != nil {
+		if req.Offset > 0 {
+			urlVal.Add("offset", strconv.Itoa(req.Offset))
+		}
+		if req.Size > 0 {
+			urlVal.Add("size", strconv.Itoa(req.Size))
+		}
+		if req.RegionId != "" {
+			urlVal.Add("regionId", req.RegionId)
+		}
+		if req.ProjectName != "" {
+			urlVal.Add("projectName", req.ProjectName)
+		}
+		if req.ResourceGroupId != "" {
+			urlVal.Add("resourceGroupId", req.ResourceGroupId)
+		}
+		if req.SearchText != "" {
+			urlVal.Add("searchText", req.SearchText)
+		}
 	}
 
 	uri := fmt.Sprintf("/?%s", urlVal.Encode())

--- a/client_interface.go
+++ b/client_interface.go
@@ -116,8 +116,9 @@ type ClientInterface interface {
 	// ref https://www.alibabacloud.com/help/doc-detail/74955.htm
 	ListProjectV2(offset, size int) (projects []LogProject, count, total int, err error)
 	ListProjectV3(req *ListProjectRequest) (projects []LogProject, count, total int, err error)
-	// ListAllProjects list all projects with type=all parameter
-	// ref https://help.aliyun.com/document_detail/xxxxx.htm
+	// ListAllProjects lists projects across all regions.
+	// This API is currently available only in supported regions, such as
+	// cn-shanghai and ap-southeast-1.
 	ListAllProjects(req *ListAllProjectsRequest) (resp *ListAllProjectsResponse, err error)
 	// CheckProjectExist check project exist or not
 	CheckProjectExist(name string) (bool, error)

--- a/client_project_test.go
+++ b/client_project_test.go
@@ -1,0 +1,68 @@
+package sls
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAllProjects(t *testing.T) {
+	const endpoint = "mock-test-endpoint.aliyuncs.com"
+	client := CreateNormalInterface(endpoint, "testAccessKeyId", "testAccessKeySecret", "").(*Client)
+	transport := httpmock.NewMockTransport()
+	client.SetHTTPClient(&http.Client{Transport: transport})
+
+	transport.RegisterResponder("GET", "http://"+endpoint+"/?offset=5&projectName=demo&regionId=cn-shanghai&resourceGroupId=rg-a&searchText=prod&size=10&type=all",
+		func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "0", req.Header.Get("x-log-bodyrawsize"))
+			require.Equal(t, endpoint, req.Host)
+			return httpmock.NewStringResponse(200, `{
+				"count": 1,
+				"total": 1,
+				"projects": [
+					{
+						"projectName": "demo-project",
+						"description": "demo",
+						"createTime": 1710000000,
+						"updateTime": 1710000100,
+						"region": "cn-hangzhou",
+						"resourceGroupId": "rg-a"
+					}
+				]
+			}`), nil
+		})
+
+	resp, err := client.ListAllProjects(&ListAllProjectsRequest{
+		Offset:          5,
+		Size:            10,
+		RegionId:        "cn-shanghai",
+		ProjectName:     "demo",
+		ResourceGroupId: "rg-a",
+		SearchText:      "prod",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, resp.Count)
+	require.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Projects, 1)
+	require.Equal(t, "demo-project", resp.Projects[0].ProjectName)
+	require.Equal(t, "cn-hangzhou", resp.Projects[0].Region)
+	require.Equal(t, "rg-a", resp.Projects[0].ResourceGroupId)
+}
+
+func TestListAllProjectsWithNilRequest(t *testing.T) {
+	const endpoint = "mock-test-endpoint.aliyuncs.com"
+	client := CreateNormalInterface(endpoint, "testAccessKeyId", "testAccessKeySecret", "").(*Client)
+	transport := httpmock.NewMockTransport()
+	client.SetHTTPClient(&http.Client{Transport: transport})
+
+	transport.RegisterResponder("GET", "http://"+endpoint+"/?type=all",
+		httpmock.NewStringResponder(200, `{"count":0,"total":0,"projects":[]}`))
+
+	resp, err := client.ListAllProjects(nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, resp.Count)
+	require.Equal(t, 0, resp.Total)
+	require.Empty(t, resp.Projects)
+}

--- a/model.go
+++ b/model.go
@@ -412,30 +412,32 @@ type ListProjectRequest struct {
 	Description string `json:"description,omitempty"` // use it to filter projects by description, support fuzzy search
 }
 
-// ListAllProjectsRequest for ListAllProjects API
+// ListAllProjectsRequest lists projects across all regions.
+// The ListAllProjects API is currently available only in supported regions,
+// such as cn-shanghai and ap-southeast-1.
 type ListAllProjectsRequest struct {
-	Offset           int    `json:"offset,omitempty"`
-	Size             int    `json:"size,omitempty"`
-	RegionId         string `json:"regionId,omitempty"`
-	ProjectName      string `json:"projectName,omitempty"`
-	ResourceGroupId  string `json:"resourceGroupId,omitempty"`
-	SearchText       string `json:"searchText,omitempty"`
+	Offset          int    `json:"offset,omitempty"`
+	Size            int    `json:"size,omitempty"`
+	RegionId        string `json:"regionId,omitempty"`
+	ProjectName     string `json:"projectName,omitempty"`
+	ResourceGroupId string `json:"resourceGroupId,omitempty"`
+	SearchText      string `json:"searchText,omitempty"`
 }
 
 // ProjectSummary for ListAllProjects response
 type ProjectSummary struct {
-	ProjectName       string `json:"projectName"`
-	Description       string `json:"description"`
-	CreateTime        int64  `json:"createTime"`
-	UpdateTime        int64  `json:"updateTime"`
-	Region            string `json:"region"`
-	ResourceGroupId   string `json:"resourceGroupId"`
+	ProjectName     string `json:"projectName"`
+	Description     string `json:"description"`
+	CreateTime      int64  `json:"createTime"`
+	UpdateTime      int64  `json:"updateTime"`
+	Region          string `json:"region"`
+	ResourceGroupId string `json:"resourceGroupId"`
 }
 
 // ListAllProjectsResponse for ListAllProjects API response
 type ListAllProjectsResponse struct {
-	Count    int             `json:"count"`
-	Total    int             `json:"total"`
+	Count    int              `json:"count"`
+	Total    int              `json:"total"`
 	Projects []ProjectSummary `json:"projects"`
 }
 


### PR DESCRIPTION
## Summary
- Document that ListAllProjects retrieves projects across all regions and is only available in supported regions such as cn-shanghai and ap-southeast-1.
- Allow ListAllProjects(nil) to request /?type=all instead of panicking.
- Add mock tests for full query parameters and nil request usage.

## Validation
- CGO_ENABLED=0 go test .
- git diff --check