### PR TITLE
[codex] add dashboard JSON fields

### DIFF
--- a/client_dashboard.go
+++ b/client_dashboard.go
@@ -40,11 +40,11 @@ type ChartDisplay struct {
 }
 
 type Chart struct {
-	Title   string         `json:"title"`
-	Type    string         `json:"type"`
-	Search  ChartSearch    `json:"search"`
-	Display ChartDisplay   `json:"display"`
-	Action  map[string]any `json:"action,omitempty"`
+	Title   string                 `json:"title"`
+	Type    string                 `json:"type"`
+	Search  ChartSearch            `json:"search"`
+	Display ChartDisplay           `json:"display"`
+	Action  map[string]interface{} `json:"action,omitempty"`
 }
 
 type Dashboard struct {

--- a/client_dashboard.go
+++ b/client_dashboard.go
@@ -8,11 +8,25 @@ import (
 )
 
 type ChartSearch struct {
-	Logstore string `json:"logstore"`
-	Topic    string `json:"topic"`
-	Query    string `json:"query"`
-	Start    string `json:"start"`
-	End      string `json:"end"`
+	Logstore       string       `json:"logstore"`
+	Topic          string       `json:"topic"`
+	Query          string       `json:"query"`
+	Start          string       `json:"start"`
+	End            string       `json:"end"`
+	ChartQueries   []ChartQuery `json:"chartQueries,omitempty"`
+	DataSourceType string       `json:"dataSourceType,omitempty"`
+}
+
+type ChartQuery struct {
+	DataSource   string `json:"datasource"`
+	DisplayName  string `json:"displayName,omitempty"`
+	Query        string `json:"query"`
+	Name         string `json:"name"`
+	TokenQuery   string `json:"tokenQuery"`
+	LegendFormat string `json:"legendFormat,omitempty"`
+	Project      string `json:"project"`
+	Logstore     string `json:"logstore"`
+	Limit        int    `json:"limit,omitempty"`
 }
 
 type ChartDisplay struct {
@@ -26,17 +40,19 @@ type ChartDisplay struct {
 }
 
 type Chart struct {
-	Title   string       `json:"title"`
-	Type    string       `json:"type"`
-	Search  ChartSearch  `json:"search"`
-	Display ChartDisplay `json:"display"`
+	Title   string         `json:"title"`
+	Type    string         `json:"type"`
+	Search  ChartSearch    `json:"search"`
+	Display ChartDisplay   `json:"display"`
+	Action  map[string]any `json:"action,omitempty"`
 }
 
 type Dashboard struct {
-	DashboardName string  `json:"dashboardName"`
-	Description   string  `json:"description"`
-	ChartList     []Chart `json:"charts"`
-	DisplayName   string  `json:"displayName"`
+	DashboardName string            `json:"dashboardName"`
+	Description   string            `json:"description"`
+	ChartList     []Chart           `json:"charts"`
+	DisplayName   string            `json:"displayName"`
+	Attribute     map[string]string `json:"attribute,omitempty"`
 }
 
 type ResponseDashboardItem struct {

--- a/client_dashboard_test.go
+++ b/client_dashboard_test.go
@@ -100,7 +100,7 @@ func TestDashboardJSONFields(t *testing.T) {
 		t.Fatalf("json.Marshal() error = %v", err)
 	}
 
-	var roundTrip map[string]any
+	var roundTrip map[string]interface{}
 	if err := json.Unmarshal(buf, &roundTrip); err != nil {
 		t.Fatalf("round-trip json.Unmarshal() error = %v", err)
 	}

--- a/client_dashboard_test.go
+++ b/client_dashboard_test.go
@@ -1,0 +1,111 @@
+package sls
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDashboardJSONFields(t *testing.T) {
+	raw := []byte(`{
+		"dashboardName": "dashboard-test",
+		"displayName": "display-test",
+		"description": "",
+		"attribute": {
+			"update": "1772461212344",
+			"remark": "modify chart",
+			"type": "grid",
+			"version": "39986382"
+		},
+		"charts": [
+			{
+				"title": "chart-test",
+				"type": "aggpro",
+				"action": {
+					"open": {
+						"type": "link"
+					}
+				},
+				"search": {
+					"query": "@",
+					"start": "-900s",
+					"topic": "",
+					"end": "now",
+					"logstore": "sls_op_log",
+					"dataSourceType": "current",
+					"chartQueries": [
+						{
+							"datasource": "logstore",
+							"displayName": "current query",
+							"query": "*",
+							"name": "A",
+							"tokenQuery": "*",
+							"project": "project-test",
+							"logstore": "logstore-test"
+						},
+						{
+							"datasource": "metricstore",
+							"query": "sum(rate(metric[1m]))",
+							"limit": 10000,
+							"name": "B",
+							"tokenQuery": "sum(rate(metric[1m]))",
+							"legendFormat": "worker",
+							"project": "project-test",
+							"logstore": "metricstore-test"
+						}
+					]
+				},
+				"display": {
+					"xPos": 1,
+					"yPos": 2,
+					"width": 8,
+					"height": 6,
+					"displayName": ""
+				}
+			}
+		]
+	}`)
+
+	var dashboard Dashboard
+	if err := json.Unmarshal(raw, &dashboard); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if got := dashboard.Attribute["update"]; got != "1772461212344" {
+		t.Fatalf("Attribute[update] = %q, want %q", got, "1772461212344")
+	}
+
+	chart := dashboard.ChartList[0]
+	if _, ok := chart.Action["open"]; !ok {
+		t.Fatalf("Action[open] is missing")
+	}
+
+	if got := chart.Search.DataSourceType; got != "current" {
+		t.Fatalf("DataSourceType = %q, want %q", got, "current")
+	}
+
+	if got := len(chart.Search.ChartQueries); got != 2 {
+		t.Fatalf("len(ChartQueries) = %d, want %d", got, 2)
+	}
+
+	if got := chart.Search.ChartQueries[0].DisplayName; got != "current query" {
+		t.Fatalf("ChartQueries[0].DisplayName = %q, want %q", got, "current query")
+	}
+
+	if got := chart.Search.ChartQueries[1].Limit; got != 10000 {
+		t.Fatalf("ChartQueries[1].Limit = %d, want %d", got, 10000)
+	}
+
+	buf, err := json.Marshal(dashboard)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var roundTrip map[string]any
+	if err := json.Unmarshal(buf, &roundTrip); err != nil {
+		t.Fatalf("round-trip json.Unmarshal() error = %v", err)
+	}
+
+	if _, ok := roundTrip["attribute"]; !ok {
+		t.Fatalf("marshaled dashboard is missing attribute")
+	}
+}


### PR DESCRIPTION
## Summary

- Add typed dashboard support for attribute, chart action, chartQueries, and dataSourceType JSON fields.
- Add ChartQuery to model logstore and metricstore query definitions.
- Add a JSON round-trip unit test for the new dashboard fields.

## Validation

- CGO_ENABLED=0 go test .
