### PR TITLE
feat(logstore): support enable modify

### DIFF
--- a/client_interface.go
+++ b/client_interface.go
@@ -132,6 +132,8 @@ type ClientInterface interface {
 	ListLogStoreV2(project string, offset, size int, telemetryType string) ([]string, error)
 	// GetLogStore returns logstore according by logstore name.
 	GetLogStore(project string, logstore string) (*LogStore, error)
+	// EnableLogStoreModify enables log modification and deletion for an existing logstore.
+	EnableLogStoreModify(project string, logstore string) error
 	// CreateLogStore creates a new logstore in SLS
 	// where name is logstore name,
 	// and ttl is time-to-live(in day) of logs,

--- a/client_logstore_modify_test.go
+++ b/client_logstore_modify_test.go
@@ -1,0 +1,48 @@
+package sls_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil/clienthelper"
+)
+
+func TestLogStoreEnableModifyJSON(t *testing.T) {
+	data, err := json.Marshal(&sls.LogStore{Name: "store-1", EnableModify: true})
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &body))
+	require.Equal(t, true, body["enableModify"])
+
+	var store sls.LogStore
+	require.NoError(t, json.Unmarshal([]byte(`{"enableModify":true}`), &store))
+	require.True(t, store.EnableModify)
+}
+
+func TestEnableLogStoreModify(t *testing.T) {
+	const (
+		project  = "my-project"
+		logstore = "my-store"
+	)
+
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	url := "http://" + project + "." + clienthelper.MockEndpoint + "/logstores/" + logstore + "/modification"
+
+	transport.RegisterResponder(http.MethodPut, url, func(req *http.Request) (*http.Response, error) {
+		var body map[string]bool
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		require.Equal(t, map[string]bool{"enabled": true}, body)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		require.Equal(t, "16", req.Header.Get("x-log-bodyrawsize"))
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	})
+
+	require.NoError(t, client.EnableLogStoreModify(project, logstore))
+}

--- a/client_project.go
+++ b/client_project.go
@@ -33,6 +33,13 @@ func (c *Client) GetLogStore(project string, logstore string) (*LogStore, error)
 	return proj.GetLogStore(logstore)
 }
 
+// EnableLogStoreModify enables log modification and deletion for an existing
+// logstore. The conversion is asynchronous.
+func (c *Client) EnableLogStoreModify(project string, logstore string) error {
+	proj := convert(c, project)
+	return proj.EnableLogStoreModify(logstore)
+}
+
 // CreateLogStore creates a new logstore in SLS,
 // where name is logstore name,
 // and ttl is time-to-live(in day) of logs,

--- a/log_project.go
+++ b/log_project.go
@@ -230,6 +230,37 @@ func (p *LogProject) GetLogStore(name string) (*LogStore, error) {
 	return s, nil
 }
 
+// EnableLogStoreModify enables log modification and deletion for an existing
+// logstore. The conversion is asynchronous; a successful response only means
+// that the request was accepted.
+func (p *LogProject) EnableLogStoreModify(name string) error {
+	body, err := json.Marshal(struct {
+		Enabled bool `json:"enabled"`
+	}{Enabled: true})
+	if err != nil {
+		return NewClientError(err)
+	}
+
+	h := map[string]string{
+		"x-log-bodyrawsize": fmt.Sprintf("%v", len(body)),
+		"Content-Type":      "application/json",
+	}
+	r, err := request(p, http.MethodPut, "/logstores/"+name+"/modification", h, body)
+	if err != nil {
+		return NewClientError(err)
+	}
+	defer r.Body.Close()
+
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return readResponseError(err)
+	}
+	if r.StatusCode != http.StatusOK {
+		return httpStatusNotOkError(buf, r.Header, r.StatusCode)
+	}
+	return nil
+}
+
 // CreateLogStore creates a new logstore in SLS,
 // where name is logstore name,
 // and ttl is time-to-live(in day) of logs,

--- a/log_store.go
+++ b/log_store.go
@@ -25,6 +25,7 @@ type LogStore struct {
 	TTL           int    `json:"ttl"`
 	ShardCount    int    `json:"shardCount"`
 	WebTracking   bool   `json:"enable_tracking"`
+	EnableModify  bool   `json:"enableModify"`
 	AutoSplit     bool   `json:"autoSplit"`
 	MaxSplitShard int    `json:"maxSplitShard"`
 

--- a/token_auto_update_client.go
+++ b/token_auto_update_client.go
@@ -303,6 +303,16 @@ func (c *TokenAutoUpdateClient) GetLogStore(project string, logstore string) (lo
 	return
 }
 
+func (c *TokenAutoUpdateClient) EnableLogStoreModify(project string, logstore string) (err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		err = c.logClient.EnableLogStoreModify(project, logstore)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}
+
 func (c *TokenAutoUpdateClient) CreateLogStore(project string, logstore string, ttl, shardCnt int, autoSplit bool, maxSplitShard int) (err error) {
 	for i := 0; i < c.maxTryTimes; i++ {
 		err = c.logClient.CreateLogStore(project, logstore, ttl, shardCnt, autoSplit, maxSplitShard)


### PR DESCRIPTION
## Summary

- expose the `enableModify` field on `LogStore`
- add `EnableLogStoreModify` for existing logstores
- support the API through `ClientInterface` and `TokenAutoUpdateClient`
- cover JSON mapping and the dedicated modification request with mock tests

The enable request sends `PUT /logstores/{logstore}/modification` with
`{"enabled":true}`. A successful response means the asynchronous conversion
was accepted.

## Testing

- `GOFLAGS=-mod=mod go test ./...` (Go 1.25.10)