### PR TITLE
feat: add Resource Policy API

### DIFF
--- a/client_interface.go
+++ b/client_interface.go
@@ -513,6 +513,12 @@ type ClientInterface interface {
 	DeleteProjectPolicy(project string) error
 	// GetProjectPolicy return project's policy.
 	GetProjectPolicy(project string) (string, error)
+	// PutResourcePolicy creates or updates a resource policy.
+	PutResourcePolicy(project string, req *PutResourcePolicyRequest) error
+	// GetResourcePolicy gets the resource policy for a project or logstore.
+	GetResourcePolicy(project string, resourceType ResourcePolicyResourceType, resourceName string) (*GetResourcePolicyResponse, error)
+	// DeleteResourcePolicy deletes the resource policy for a project or logstore.
+	DeleteResourcePolicy(project string, resourceType ResourcePolicyResourceType, resourceName string) error
 
 	// #################### AlertPub Msg  #####################
 	PublishAlertEvent(project string, alertResult []byte) error

--- a/client_resource_policy.go
+++ b/client_resource_policy.go
@@ -1,0 +1,132 @@
+package sls
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// ResourcePolicyResourceType identifies a resource supported by the Resource
+// Policy API.
+type ResourcePolicyResourceType string
+
+const (
+	ResourcePolicyProject  ResourcePolicyResourceType = "project"
+	ResourcePolicyLogstore ResourcePolicyResourceType = "logstore"
+)
+
+// PutResourcePolicyRequest defines a resource policy to create or update.
+type PutResourcePolicyRequest struct {
+	ResourceType   ResourcePolicyResourceType `json:"resourceType"`
+	ResourceName   string                     `json:"resourceName,omitempty"`
+	PolicyDocument string                     `json:"policyDocument"`
+	DryRun         bool                       `json:"dryRun"`
+}
+
+// GetResourcePolicyResponse describes a resource policy returned by SLS.
+type GetResourcePolicyResponse struct {
+	ResourceType   ResourcePolicyResourceType `json:"resourceType"`
+	ResourceName   string                     `json:"resourceName,omitempty"`
+	PolicyDocument string                     `json:"policyDocument"`
+	Revision       int64                      `json:"revision"`
+	CreateTime     int64                      `json:"createTime"`
+	UpdateTime     int64                      `json:"updateTime"`
+}
+
+// PutResourcePolicy creates or updates a resource policy.
+func (c *Client) PutResourcePolicy(project string, req *PutResourcePolicyRequest) error {
+	if req == nil {
+		return NewClientError(errors.New("resource policy request must not be nil"))
+	}
+	if err := validateResourcePolicyTarget(project, req.ResourceType); err != nil {
+		return err
+	}
+	if req.PolicyDocument == "" {
+		return NewClientError(errors.New("policy document must not be empty"))
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return NewClientError(err)
+	}
+	h := map[string]string{
+		"x-log-bodyrawsize": fmt.Sprintf("%d", len(body)),
+		"Content-Type":      "application/json",
+	}
+
+	r, err := c.request(project, http.MethodPut, "/resource-policies", h, body)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	return nil
+}
+
+// GetResourcePolicy gets the resource policy for a project or logstore.
+func (c *Client) GetResourcePolicy(project string, resourceType ResourcePolicyResourceType, resourceName string) (*GetResourcePolicyResponse, error) {
+	if err := validateResourcePolicyTarget(project, resourceType); err != nil {
+		return nil, err
+	}
+
+	h := map[string]string{
+		"x-log-bodyrawsize": "0",
+		"Content-Type":      "application/json",
+	}
+	uri := "/resource-policies?" + resourcePolicyTargetQuery(resourceType, resourceName)
+	r, err := c.request(project, http.MethodGet, uri, h, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, readResponseError(err)
+	}
+	resp := &GetResourcePolicyResponse{}
+	if err = json.Unmarshal(body, resp); err != nil {
+		return nil, NewClientError(err)
+	}
+	return resp, nil
+}
+
+// DeleteResourcePolicy deletes the resource policy for a project or logstore.
+func (c *Client) DeleteResourcePolicy(project string, resourceType ResourcePolicyResourceType, resourceName string) error {
+	if err := validateResourcePolicyTarget(project, resourceType); err != nil {
+		return err
+	}
+
+	h := map[string]string{
+		"x-log-bodyrawsize": "0",
+		"Content-Type":      "application/json",
+	}
+	uri := "/resource-policies?" + resourcePolicyTargetQuery(resourceType, resourceName)
+	r, err := c.request(project, http.MethodDelete, uri, h, nil)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	return nil
+}
+
+func validateResourcePolicyTarget(project string, resourceType ResourcePolicyResourceType) error {
+	if project == "" {
+		return NewClientError(errors.New("project must not be empty"))
+	}
+	if resourceType != ResourcePolicyProject && resourceType != ResourcePolicyLogstore {
+		return NewClientError(errors.New("resource type must be project or logstore"))
+	}
+	return nil
+}
+
+func resourcePolicyTargetQuery(resourceType ResourcePolicyResourceType, resourceName string) string {
+	v := url.Values{}
+	v.Add("resourceType", string(resourceType))
+	if resourceName != "" {
+		v.Add("resourceName", resourceName)
+	}
+	return v.Encode()
+}

--- a/client_resource_policy_test.go
+++ b/client_resource_policy_test.go
@@ -1,0 +1,173 @@
+package sls_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil/clienthelper"
+)
+
+const (
+	resourcePolicyProject  = "resource-policy-project"
+	resourcePolicyLogstore = "resource-policy-logstore"
+	resourcePolicyDocument = `{"Version":"1","Statement":[]}`
+)
+
+func TestPutResourcePolicy(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	url := "http://" + resourcePolicyProject + "." + clienthelper.MockEndpoint + "/resource-policies"
+
+	var bodies []map[string]interface{}
+	transport.RegisterResponder(http.MethodPut, url, func(req *http.Request) (*http.Response, error) {
+		rawBody, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		var body map[string]interface{}
+		require.NoError(t, json.Unmarshal(rawBody, &body))
+		bodies = append(bodies, body)
+		require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+		require.Equal(t, strconv.Itoa(len(rawBody)), req.Header.Get("x-log-bodyrawsize"))
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	})
+
+	require.NoError(t, client.PutResourcePolicy(resourcePolicyProject, &sls.PutResourcePolicyRequest{
+		ResourceType:   sls.ResourcePolicyProject,
+		PolicyDocument: resourcePolicyDocument,
+	}))
+	require.NoError(t, client.PutResourcePolicy(resourcePolicyProject, &sls.PutResourcePolicyRequest{
+		ResourceType:   sls.ResourcePolicyLogstore,
+		ResourceName:   resourcePolicyLogstore,
+		PolicyDocument: resourcePolicyDocument,
+		DryRun:         true,
+	}))
+
+	require.Equal(t, []map[string]interface{}{
+		{
+			"resourceType":   "project",
+			"policyDocument": resourcePolicyDocument,
+			"dryRun":         false,
+		},
+		{
+			"resourceType":   "logstore",
+			"resourceName":   resourcePolicyLogstore,
+			"policyDocument": resourcePolicyDocument,
+			"dryRun":         true,
+		},
+	}, bodies)
+}
+
+func TestGetResourcePolicy(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	url := "http://" + resourcePolicyProject + "." + clienthelper.MockEndpoint +
+		"/resource-policies?resourceName=" + resourcePolicyLogstore + "&resourceType=logstore"
+
+	transport.RegisterResponder(http.MethodGet, url, func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "0", req.Header.Get("x-log-bodyrawsize"))
+		return httpmock.NewJsonResponse(http.StatusOK, map[string]interface{}{
+			"resourceType":   "logstore",
+			"resourceName":   resourcePolicyLogstore,
+			"policyDocument": resourcePolicyDocument,
+			"revision":       3,
+			"createTime":     10,
+			"updateTime":     20,
+		})
+	})
+
+	resp, err := client.GetResourcePolicy(
+		resourcePolicyProject, sls.ResourcePolicyLogstore, resourcePolicyLogstore,
+	)
+	require.NoError(t, err)
+	require.Equal(t, sls.ResourcePolicyLogstore, resp.ResourceType)
+	require.Equal(t, resourcePolicyLogstore, resp.ResourceName)
+	require.Equal(t, resourcePolicyDocument, resp.PolicyDocument)
+	require.EqualValues(t, 3, resp.Revision)
+	require.EqualValues(t, 10, resp.CreateTime)
+	require.EqualValues(t, 20, resp.UpdateTime)
+}
+
+func TestGetProjectResourcePolicyOmitsResourceNameAndUsesResponseTarget(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	url := "http://" + resourcePolicyProject + "." + clienthelper.MockEndpoint +
+		"/resource-policies?resourceType=project"
+
+	testutil.RegisterJSON(t, transport, http.MethodGet, url, http.StatusOK, map[string]interface{}{
+		"resourceType":   "logstore",
+		"resourceName":   "unexpected",
+		"policyDocument": resourcePolicyDocument,
+		"revision":       1,
+		"createTime":     2,
+		"updateTime":     3,
+	})
+
+	resp, err := client.GetResourcePolicy(resourcePolicyProject, sls.ResourcePolicyProject, "")
+	require.NoError(t, err)
+	require.Equal(t, sls.ResourcePolicyLogstore, resp.ResourceType)
+	require.Equal(t, "unexpected", resp.ResourceName)
+}
+
+func TestDeleteResourcePolicy(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	url := "http://" + resourcePolicyProject + "." + clienthelper.MockEndpoint +
+		"/resource-policies?resourceType=project"
+
+	transport.RegisterResponder(http.MethodDelete, url, func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "0", req.Header.Get("x-log-bodyrawsize"))
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	})
+
+	require.NoError(t, client.DeleteResourcePolicy(resourcePolicyProject, sls.ResourcePolicyProject, ""))
+}
+
+func TestResourcePolicyValidation(t *testing.T) {
+	client := clienthelper.NewMockedClient(testutil.NewMockTransport())
+
+	require.Error(t, client.PutResourcePolicy(resourcePolicyProject, nil))
+	require.Error(t, client.PutResourcePolicy("", &sls.PutResourcePolicyRequest{
+		ResourceType:   sls.ResourcePolicyProject,
+		PolicyDocument: resourcePolicyDocument,
+	}))
+	require.Error(t, client.PutResourcePolicy(resourcePolicyProject, &sls.PutResourcePolicyRequest{
+		ResourceType: sls.ResourcePolicyProject,
+	}))
+	_, err := client.GetResourcePolicy(resourcePolicyProject, "", "")
+	require.Error(t, err)
+	_, err = client.GetResourcePolicy(resourcePolicyProject, "dashboard", "")
+	require.Error(t, err)
+	require.Error(t, client.DeleteResourcePolicy(resourcePolicyProject, "", ""))
+}
+
+func TestResourcePolicyTargetValidationIsDelegatedToServer(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	putURL := "http://" + resourcePolicyProject + "." + clienthelper.MockEndpoint + "/resource-policies"
+	deleteURL := putURL + "?resourceName=" + resourcePolicyLogstore + "&resourceType=project"
+
+	transport.RegisterResponder(http.MethodPut, putURL, func(req *http.Request) (*http.Response, error) {
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		require.Equal(t, resourcePolicyLogstore, body["resourceName"])
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	})
+	transport.RegisterResponder(http.MethodDelete, deleteURL,
+		httpmock.NewStringResponder(http.StatusOK, ""))
+
+	require.NoError(t, client.PutResourcePolicy(resourcePolicyProject, &sls.PutResourcePolicyRequest{
+		ResourceType:   sls.ResourcePolicyProject,
+		ResourceName:   resourcePolicyLogstore,
+		PolicyDocument: resourcePolicyDocument,
+	}))
+	require.NoError(t, client.DeleteResourcePolicy(
+		resourcePolicyProject, sls.ResourcePolicyProject, resourcePolicyLogstore,
+	))
+}

--- a/token_auto_update_client.go
+++ b/token_auto_update_client.go
@@ -2070,6 +2070,36 @@ func (c *TokenAutoUpdateClient) GetProjectPolicy(project string) (policy string,
 	return
 }
 
+func (c *TokenAutoUpdateClient) PutResourcePolicy(project string, req *PutResourcePolicyRequest) (err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		err = c.logClient.PutResourcePolicy(project, req)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}
+
+func (c *TokenAutoUpdateClient) GetResourcePolicy(project string, resourceType ResourcePolicyResourceType, resourceName string) (resp *GetResourcePolicyResponse, err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		resp, err = c.logClient.GetResourcePolicy(project, resourceType, resourceName)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}
+
+func (c *TokenAutoUpdateClient) DeleteResourcePolicy(project string, resourceType ResourcePolicyResourceType, resourceName string) (err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		err = c.logClient.DeleteResourcePolicy(project, resourceType, resourceName)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}
+
 func (c *TokenAutoUpdateClient) PublishAlertEvent(project string, alertResult []byte) error {
 	var err error = nil
 	for i := 0; i < c.maxTryTimes; i++ {


### PR DESCRIPTION
## Summary

- add typed Put, Get, and Delete Resource Policy APIs for projects and logstores
- expose the APIs through ClientInterface and TokenAutoUpdateClient
- add HTTP mock coverage for request serialization, response parsing, and validation

## Testing

- go test ./...
- docker/build-test-all.sh go

Reference: https://github.com/aliyun/aliyun-log-java-sdk/pull/224