### PR TITLE
feat: add EncryptConf support for MetricStore

### DIFF
--- a/metric_store_v2.go
+++ b/metric_store_v2.go
@@ -14,6 +14,35 @@ type MetricStore struct {
 	InfrequentAccessTTL *int32 `json:"infrequentAccessTTL,omitempty"` // 0 means infrequentAccessTTL = 0
 	Mode                string `json:"mode,omitempty"`                // "query" or "standard"(default), can't be modified after creation
 
+	// EncryptConf holds the encryption config of the metric store.
+	// Contract verified by e2e tests against the /metricstores API (note: this
+	// API speaks camelCase, unlike the snake_case /logstores API):
+	//   - create and update share the same semantics: once encryption is enabled,
+	//     the config is immutable — an update carrying a different config is
+	//     rejected (400 ParameterInvalid), while disabling (enable=false) or
+	//     re-enabling with the identical config is allowed;
+	//   - nil omits the field from the request, leaving the server-side
+	//     encryption state untouched.
+	EncryptConf *MetricStoreEncryptConf `json:"encryptConf,omitempty"`
+
 	CreateTime     uint32 `json:"createTime,omitempty"`
 	LastModifyTime uint32 `json:"lastModifyTime,omitempty"`
+}
+
+// MetricStoreEncryptConf is the encryption config for /metricstores APIs.
+// It mirrors EncryptConf but with camelCase JSON keys: the /metricstores API
+// silently ignores the snake_case keys (encrypt_conf/encrypt_type) used by
+// the /logstores API, so reusing EncryptConf here would not work.
+type MetricStoreEncryptConf struct {
+	Enable      bool                           `json:"enable"`
+	EncryptType string                         `json:"encryptType"` // e.g. "default", "m4"
+	UserCmkInfo *MetricStoreEncryptUserCmkConf `json:"userCmkInfo,omitempty"`
+}
+
+// MetricStoreEncryptUserCmkConf is the BYOK (user CMK) config for metric
+// stores, the camelCase counterpart of EncryptUserCmkConf.
+type MetricStoreEncryptUserCmkConf struct {
+	CmkKeyId string `json:"cmkKeyId"`
+	Arn      string `json:"arn"`
+	RegionId string `json:"regionId"`
 }

--- a/metric_store_v2_test.go
+++ b/metric_store_v2_test.go
@@ -1,0 +1,89 @@
+package sls_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+)
+
+func TestMetricStoreEncryptConfJSON(t *testing.T) {
+	store := &sls.MetricStore{
+		Name:       "store-1",
+		TTL:        30,
+		ShardCount: 2,
+		EncryptConf: &sls.MetricStoreEncryptConf{
+			Enable:      true,
+			EncryptType: "m4",
+			UserCmkInfo: &sls.MetricStoreEncryptUserCmkConf{
+				CmkKeyId: "key-id",
+				Arn:      "acs:ram::123456:role/test-role",
+				RegionId: "cn-hangzhou",
+			},
+		},
+	}
+	data, err := json.Marshal(store)
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &body))
+	// the /metricstores API speaks camelCase; snake_case keys are ignored by the server
+	require.Contains(t, body, "encryptConf")
+	encryptConf, ok := body["encryptConf"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, encryptConf["enable"])
+	require.Equal(t, "m4", encryptConf["encryptType"])
+	cmkInfo, ok := encryptConf["userCmkInfo"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "key-id", cmkInfo["cmkKeyId"])
+	require.Equal(t, "acs:ram::123456:role/test-role", cmkInfo["arn"])
+	require.Equal(t, "cn-hangzhou", cmkInfo["regionId"])
+
+	var decoded sls.MetricStore
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.EncryptConf)
+	require.True(t, decoded.EncryptConf.Enable)
+	require.Equal(t, "m4", decoded.EncryptConf.EncryptType)
+	require.Equal(t, "key-id", decoded.EncryptConf.UserCmkInfo.CmkKeyId)
+	require.Equal(t, "acs:ram::123456:role/test-role", decoded.EncryptConf.UserCmkInfo.Arn)
+	require.Equal(t, "cn-hangzhou", decoded.EncryptConf.UserCmkInfo.RegionId)
+}
+
+// A nil EncryptConf must be omitted from the request body so the field is
+// simply absent from the serialized request.
+func TestMetricStoreEncryptConfOmitted(t *testing.T) {
+	store := &sls.MetricStore{
+		Name:       "store-1",
+		TTL:        30,
+		ShardCount: 2,
+	}
+	data, err := json.Marshal(store)
+	require.NoError(t, err)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &body))
+	require.NotContains(t, body, "encryptConf")
+
+	var decoded sls.MetricStore
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Nil(t, decoded.EncryptConf)
+}
+
+// Encryption can be requested disabled by carrying the config with Enable=false.
+func TestMetricStoreEncryptConfDisable(t *testing.T) {
+	store := &sls.MetricStore{
+		Name:       "store-1",
+		TTL:        30,
+		ShardCount: 2,
+		EncryptConf: &sls.MetricStoreEncryptConf{
+			Enable:      false,
+			EncryptType: "m4",
+		},
+	}
+	data, err := json.Marshal(store)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `"encryptConf"`)
+	require.Contains(t, string(data), `"enable":false`)
+}


### PR DESCRIPTION
## Summary
- Add `EncryptConf` field to `MetricStore` so encryption config can be set via the `/metricstores` APIs (`CreateMetricStoreV2` / `UpdateMetricStoreV2`).
- Introduce `MetricStoreEncryptConf` / `MetricStoreEncryptUserCmkConf` with camelCase JSON keys: the `/metricstores` API silently ignores the snake_case keys (`encrypt_conf` / `encrypt_type`) used by the `/logstores` API, so reusing `EncryptConf` would not work.
- `EncryptConf` is a pointer with `omitempty`: a nil value omits the field from the request, leaving the server-side encryption state untouched.

## Test plan
- [x] `go build ./...` and `go vet` pass
- [x] New unit tests cover JSON round-trip (camelCase keys), nil omission, and `enable=false` serialization