### PR TITLE
fix: use labels type for legacy MetricStore creation

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,12 @@
 # Breaking Changes
 
+## v0.1.128 (2026-09-07)
+
+### MetricStore default change
+
+- The deprecated `CreateMetricStore` path now creates MetricStore V2 by using the `labels` type for `__labels__` in the default `prom` substore.
+- Substore key validation now accepts the `labels` type.
+
 ## v0.1.124 (2026-08-06)
 
 ### ⚠️ Module Change: Store View Routing Checker

--- a/client_metric_store.go
+++ b/client_metric_store.go
@@ -22,7 +22,7 @@ func (c *Client) CreateMetricStore(project string, metricStore *LogStore) error 
 		Type: "text",
 	}, SubStoreKey{
 		Name: "__labels__",
-		Type: "text",
+		Type: "labels",
 	}, SubStoreKey{
 		Name: "__time_nano__",
 		Type: "long",

--- a/client_metric_store_mock_test.go
+++ b/client_metric_store_mock_test.go
@@ -1,0 +1,47 @@
+package sls_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil/clienthelper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateMetricStoreMock(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	var paths []string
+	var logstore sls.LogStore
+	var substore sls.SubStore
+	for _, path := range []string{"/logstores", "/logstores/my-metrics/substores"} {
+		transport.RegisterResponder("POST", "http://my-project."+clienthelper.MockEndpoint+path,
+			func(req *http.Request) (*http.Response, error) {
+				paths = append(paths, req.URL.Path)
+				if req.URL.Path == "/logstores" {
+					require.NoError(t, json.NewDecoder(req.Body).Decode(&logstore))
+				} else {
+					require.NoError(t, json.NewDecoder(req.Body).Decode(&substore))
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+			})
+	}
+
+	require.NoError(t, client.CreateMetricStore("my-project", &sls.LogStore{Name: "my-metrics", TTL: 18, ShardCount: 2}))
+	require.Equal(t, []string{"/logstores", "/logstores/my-metrics/substores"}, paths)
+	require.Equal(t, "Metrics", logstore.TelemetryType)
+	require.Equal(t, "my-metrics", logstore.Name)
+	require.Equal(t, 18, logstore.TTL)
+	require.Equal(t, sls.SubStore{
+		Name: "prom", TTL: 18, SortedKeyCount: 2, TimeIndex: 2,
+		Keys: []sls.SubStoreKey{
+			{Name: "__name__", Type: "text"},
+			{Name: "__labels__", Type: "labels"},
+			{Name: "__time_nano__", Type: "long"},
+			{Name: "__value__", Type: "double"},
+		},
+	}, substore)
+}

--- a/sub_store.go
+++ b/sub_store.go
@@ -12,6 +12,7 @@ func (s *SubStoreKey) IsValid() bool {
 		return false
 	}
 	if s.Type != "text" &&
+		s.Type != "labels" &&
 		s.Type != "long" &&
 		s.Type != "double" {
 		return false


### PR DESCRIPTION
The deprecated `CreateMetricStore` flow still creates a logstore followed by a `prom` substore. Its default `__labels__` key now uses `labels` instead of `text`, selecting MetricStore V2. Substore validation accepts `labels` so this path does not panic before sending the request.

Adds a mocked HTTP regression test that checks both creation requests, their order, and the complete default substore schema. Records the default behavior change for the next patch release, v0.1.128; Go release versions are managed by tags.

Validation: Docker `go build ./...` and `go test ./...` both passed. Self review covers compatibility, scope, schema validation, and committed file contents. Live SLS integration tests were not run.
