### PR TITLE
feat: add synchronous log update and delete APIs

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -5,6 +5,7 @@
 ### ClientInterface additions
 
 - Added synchronous `UpdateLogStoreLogs` and `DeleteLogStoreLogs` APIs returning `affectedRows`, with support in `Client` and `TokenAutoUpdateClient`. Custom implementations of `ClientInterface` must implement these two methods.
+- Added creation-time `EnableModify` request coverage and an E2E test for both enablement paths followed by synchronous update/delete.
 - Enable log modification with the existing `EnableLogStoreModify` API or `LogStore.EnableModify` before updating or deleting logs.
 
 ## v0.1.128 (2026-09-07)

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -5,8 +5,9 @@
 ### ClientInterface additions
 
 - Added synchronous `UpdateLogStoreLogs` and `DeleteLogStoreLogs` APIs returning `affectedRows`, with support in `Client` and `TokenAutoUpdateClient`. Custom implementations of `ClientInterface` must implement these two methods.
+- Added a runnable example for creation-time enablement, synchronous updates/deletes, and resource cleanup.
 - Added creation-time `EnableModify` request coverage and an E2E test for both enablement paths followed by synchronous update/delete.
-- Enable log modification with the existing `EnableLogStoreModify` API or `LogStore.EnableModify` before updating or deleting logs.
+- Enable log modification with `LogStore.EnableModify` at creation; the existing `EnableLogStoreModify` API requires support from the target service.
 
 ## v0.1.128 (2026-09-07)
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,12 @@
 # Breaking Changes
 
+## v0.1.129 (2026-09-08)
+
+### ClientInterface additions
+
+- Added synchronous `UpdateLogStoreLogs` and `DeleteLogStoreLogs` APIs returning `affectedRows`, with support in `Client` and `TokenAutoUpdateClient`. Custom implementations of `ClientInterface` must implement these two methods.
+- Enable log modification with the existing `EnableLogStoreModify` API or `LogStore.EnableModify` before updating or deleting logs.
+
 ## v0.1.128 (2026-09-07)
 
 ### MetricStore default change

--- a/README.md
+++ b/README.md
@@ -284,3 +284,33 @@ if err != nil {
 ```
 protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --gofast_out=. log.proto
 ```
+
+### 同步更新和删除日志
+
+先通过 `client.EnableLogStoreModify(project, logstore)` 为已有 Logstore 开启修改能力；
+创建 Logstore 时也可以设置 `LogStore.EnableModify = true`。
+`UpdateLogStoreLogs` 和 `DeleteLogStoreLogs` 同步返回 `AffectedRows`，不创建 task。
+可通过 `RowID` 定位日志，或使用 `From`、`To`（Unix 秒时间戳指针）和 `Query` 筛选。
+时间指针为 `nil` 时不发送该字段，指向 `0` 时会发送时间戳零。
+
+```go
+updated, err := client.UpdateLogStoreLogs(project, logstore, &sls.UpdateLogStoreLogsRequest{
+    RowID: "your-row-id",
+    Data:  `{"status":"processed"}`,
+})
+if err != nil {
+    return err
+}
+fmt.Println(updated.AffectedRows)
+
+deleted, err := client.DeleteLogStoreLogs(project, logstore, &sls.DeleteLogStoreLogsRequest{
+    RowID: "your-row-id",
+})
+if err != nil {
+    return err
+}
+fmt.Println(deleted.AffectedRows)
+```
+
+`Data` 是 JSON 编码后的字符串。`UpdateMode` 原样传递给服务端，留空时省略。
+这两个接口也支持 `TokenAutoUpdateClient`。

--- a/README.md
+++ b/README.md
@@ -287,11 +287,14 @@ protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --go
 
 ### 同步更新和删除日志
 
-先通过 `client.EnableLogStoreModify(project, logstore)` 为已有 Logstore 开启修改能力；
-创建 Logstore 时也可以设置 `LogStore.EnableModify = true`。
+创建 Logstore 时设置 `LogStore.EnableModify = true` 开启修改能力。
+[官网功能说明](https://help.aliyun.com/zh/sls/modifying-and-deleting-log-data)目前仅承诺创建时开启；
+已有 Logstore 的 `client.EnableLogStoreModify(project, logstore)` 需要目标服务端支持，不能假设所有环境均已开放。
 `UpdateLogStoreLogs` 和 `DeleteLogStoreLogs` 同步返回 `AffectedRows`，不创建 task。
 `From`、`To` 是必填的 Unix 秒时间戳（`int64`），表示左闭右开的 `[From, To)` 区间。
 使用 `RowID` 或 `Query` 筛选时都必须提供时间范围；零值也会发送，范围有效性由服务端校验。
+`Query` 与 `RowID` 至少提供一个，同时提供时由服务端优先使用 `RowID`。
+`Query` 仅支持搜索表达式，不支持 SQL 或 SPL，涉及的字段需已建立索引。
 
 ```go
 updated, err := client.UpdateLogStoreLogs(project, logstore, &sls.UpdateLogStoreLogsRequest{
@@ -316,5 +319,7 @@ if err != nil {
 fmt.Println(deleted.AffectedRows)
 ```
 
-`Data` 是 JSON 编码后的字符串。`UpdateMode` 支持 `full` 和 `partial`，留空时由服务端默认为 `partial`。
+`Data` 是 JSON 编码后的字符串，留空时省略该字段。`UpdateMode` 支持 `full` 和 `partial`，留空时由服务端默认为 `partial`。
 这两个接口也支持 `TokenAutoUpdateClient`。
+
+完整可运行示例：[同步更新和删除日志](example/logstore/modify_logs/README.md)。

--- a/README.md
+++ b/README.md
@@ -290,11 +290,13 @@ protoc -I=. -I=$GOPATH/src -I=$GOPATH/src/github.com/gogo/protobuf/protobuf --go
 先通过 `client.EnableLogStoreModify(project, logstore)` 为已有 Logstore 开启修改能力；
 创建 Logstore 时也可以设置 `LogStore.EnableModify = true`。
 `UpdateLogStoreLogs` 和 `DeleteLogStoreLogs` 同步返回 `AffectedRows`，不创建 task。
-可通过 `RowID` 定位日志，或使用 `From`、`To`（Unix 秒时间戳指针）和 `Query` 筛选。
-时间指针为 `nil` 时不发送该字段，指向 `0` 时会发送时间戳零。
+`From`、`To` 是必填的 Unix 秒时间戳（`int64`），表示左闭右开的 `[From, To)` 区间。
+使用 `RowID` 或 `Query` 筛选时都必须提供时间范围；零值也会发送，范围有效性由服务端校验。
 
 ```go
 updated, err := client.UpdateLogStoreLogs(project, logstore, &sls.UpdateLogStoreLogsRequest{
+    From:  1700000000,
+    To:    1700000100,
     RowID: "your-row-id",
     Data:  `{"status":"processed"}`,
 })
@@ -304,6 +306,8 @@ if err != nil {
 fmt.Println(updated.AffectedRows)
 
 deleted, err := client.DeleteLogStoreLogs(project, logstore, &sls.DeleteLogStoreLogsRequest{
+    From:  1700000000,
+    To:    1700000100,
     RowID: "your-row-id",
 })
 if err != nil {
@@ -312,5 +316,5 @@ if err != nil {
 fmt.Println(deleted.AffectedRows)
 ```
 
-`Data` 是 JSON 编码后的字符串。`UpdateMode` 原样传递给服务端，留空时省略。
+`Data` 是 JSON 编码后的字符串。`UpdateMode` 支持 `full` 和 `partial`，留空时由服务端默认为 `partial`。
 这两个接口也支持 `TokenAutoUpdateClient`。

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,11 +93,12 @@ and `LOG_TEST_PROJECT` configured for a test project, run:
 go test -tags=e2e . -run '^TestLogStoreLogsE2E$' -v -count=1 -timeout=20m
 ```
 
-This test creates two temporary, one-shard Logstores with one-day retention in
-the supplied project. It covers `LogStore.EnableModify` at creation and
-`EnableLogStoreModify` after creation, writes synthetic records, updates and
+This test creates temporary, one-shard Logstores with one-day retention in
+the supplied project. It covers `LogStore.EnableModify` at creation. Set
+`LOG_TEST_ENABLE_EXISTING_MODIFY=true` to also test `EnableLogStoreModify`
+after creation, only on a service that supports this API. The test writes synthetic records, updates and
 deletes them by query and row ID, and verifies the affected counts and query
-results. Both stores are deleted by test cleanup. The account needs Logstore
+results. All created stores are deleted by test cleanup. The account needs Logstore
 and index management, write, query, modification-enable, update, and delete
 permissions. Do not run this against a project where test resource creation
 is unwanted.

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,3 +83,21 @@ When extracting an e2e suite from a mixed file, leave the unit-only logic in the
 
 - `TestSignerV4Suite/TestSignV1Case{1,2}` in `signature_v4_test.go` is currently failing on master (expected `"SLS"` prefix vs production `"LOG"` prefix). Pre-existing — not introduced by the unit/e2e split.
 - The `cgo/` subpackage is not built by default. It depends on `github.com/DataDog/zstd` and requires a working CGO toolchain. Skip it in environments without one.
+
+## Synchronous log mutation E2E test
+
+With `LOG_TEST_ENDPOINT`, `LOG_TEST_ACCESS_KEY_ID`, `LOG_TEST_ACCESS_KEY_SECRET`,
+and `LOG_TEST_PROJECT` configured for a test project, run:
+
+```bash
+go test -tags=e2e . -run '^TestLogStoreLogsE2E$' -v -count=1 -timeout=20m
+```
+
+This test creates two temporary, one-shard Logstores with one-day retention in
+the supplied project. It covers `LogStore.EnableModify` at creation and
+`EnableLogStoreModify` after creation, writes synthetic records, updates and
+deletes them by query and row ID, and verifies the affected counts and query
+results. Both stores are deleted by test cleanup. The account needs Logstore
+and index management, write, query, modification-enable, update, and delete
+permissions. Do not run this against a project where test resource creation
+is unwanted.

--- a/client_interface.go
+++ b/client_interface.go
@@ -134,6 +134,10 @@ type ClientInterface interface {
 	GetLogStore(project string, logstore string) (*LogStore, error)
 	// EnableLogStoreModify enables log modification and deletion for an existing logstore.
 	EnableLogStoreModify(project string, logstore string) error
+	// UpdateLogStoreLogs synchronously updates logs and returns the affected row count.
+	UpdateLogStoreLogs(project, logstore string, req *UpdateLogStoreLogsRequest) (*UpdateLogStoreLogsResponse, error)
+	// DeleteLogStoreLogs synchronously deletes logs and returns the affected row count.
+	DeleteLogStoreLogs(project, logstore string, req *DeleteLogStoreLogsRequest) (*DeleteLogStoreLogsResponse, error)
 	// CreateLogStore creates a new logstore in SLS
 	// where name is logstore name,
 	// and ttl is time-to-live(in day) of logs,

--- a/client_logstore_logs.go
+++ b/client_logstore_logs.go
@@ -1,0 +1,96 @@
+package sls
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// UpdateLogStoreLogsRequest selects logs by time range and query, or by row ID.
+// From and To are Unix timestamps in seconds; nil omits the corresponding bound.
+type UpdateLogStoreLogsRequest struct {
+	From  *int64 `json:"from,omitempty"`
+	To    *int64 `json:"to,omitempty"`
+	Query string `json:"query,omitempty"`
+	RowID string `json:"rowId,omitempty"`
+	// UpdateMode is passed through to the service.
+	UpdateMode string `json:"updateMode,omitempty"`
+	// Data is a JSON-encoded string containing the fields to update.
+	Data string `json:"data"`
+}
+
+// UpdateLogStoreLogsResponse reports the number of logs affected synchronously.
+type UpdateLogStoreLogsResponse struct {
+	AffectedRows int64 `json:"affectedRows"`
+}
+
+// UpdateLogStoreLogs synchronously updates logs and returns the affected row count.
+// Log modification must be enabled on the logstore using EnableLogStoreModify
+// or LogStore.EnableModify. This API does not create an asynchronous task.
+func (c *Client) UpdateLogStoreLogs(project, logstore string, req *UpdateLogStoreLogsRequest) (*UpdateLogStoreLogsResponse, error) {
+	if req == nil {
+		return nil, NewClientError(errors.New("update logs request must not be nil"))
+	}
+	resp := &UpdateLogStoreLogsResponse{}
+	if err := c.modifyLogStoreLogs(project, logstore, "updatelogs", req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DeleteLogStoreLogsRequest selects logs by time range and query, or by row ID.
+// From and To are Unix timestamps in seconds; nil omits the corresponding bound.
+type DeleteLogStoreLogsRequest struct {
+	From  *int64 `json:"from,omitempty"`
+	To    *int64 `json:"to,omitempty"`
+	Query string `json:"query,omitempty"`
+	RowID string `json:"rowId,omitempty"`
+}
+
+// DeleteLogStoreLogsResponse reports the number of logs affected synchronously.
+type DeleteLogStoreLogsResponse struct {
+	AffectedRows int64 `json:"affectedRows"`
+}
+
+// DeleteLogStoreLogs synchronously deletes logs and returns the affected row count.
+// Log modification must be enabled on the logstore using EnableLogStoreModify
+// or LogStore.EnableModify. This API does not create an asynchronous task.
+func (c *Client) DeleteLogStoreLogs(project, logstore string, req *DeleteLogStoreLogsRequest) (*DeleteLogStoreLogsResponse, error) {
+	if req == nil {
+		return nil, NewClientError(errors.New("delete logs request must not be nil"))
+	}
+	resp := &DeleteLogStoreLogsResponse{}
+	if err := c.modifyLogStoreLogs(project, logstore, "deletelogs", req, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (c *Client) modifyLogStoreLogs(project, logstore, operation string, req, result interface{}) error {
+	if project == "" || logstore == "" {
+		return NewClientError(errors.New("project and logstore must not be empty"))
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return NewClientError(err)
+	}
+	headers := map[string]string{
+		"Content-Type":      "application/json",
+		"x-log-bodyrawsize": fmt.Sprintf("%d", len(body)),
+	}
+	r, err := c.request(project, http.MethodPost, "/logstores/"+logstore+"/"+operation, headers, body)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+	body, err = ioutil.ReadAll(r.Body)
+	if err != nil {
+		return readResponseError(err)
+	}
+	if err = json.Unmarshal(body, result); err != nil {
+		return NewClientError(err)
+	}
+	return nil
+}

--- a/client_logstore_logs.go
+++ b/client_logstore_logs.go
@@ -11,6 +11,8 @@ import (
 // UpdateLogStoreLogsRequest selects logs by time range and query, or by row ID.
 // From and To are required Unix timestamps in seconds defining [From, To),
 // including when selecting by row ID. The service validates the time range.
+// Specify Query or RowID; if both are set, the service gives RowID precedence.
+// Query accepts search expressions, not SQL or SPL.
 type UpdateLogStoreLogsRequest struct {
 	From  int64  `json:"from"`
 	To    int64  `json:"to"`
@@ -19,7 +21,7 @@ type UpdateLogStoreLogsRequest struct {
 	// UpdateMode is full or partial; when omitted, the service defaults to partial.
 	UpdateMode string `json:"updateMode,omitempty"`
 	// Data is a JSON-encoded string containing the fields to update.
-	Data string `json:"data"`
+	Data string `json:"data,omitempty"`
 }
 
 // UpdateLogStoreLogsResponse reports the number of logs affected synchronously.
@@ -28,8 +30,8 @@ type UpdateLogStoreLogsResponse struct {
 }
 
 // UpdateLogStoreLogs synchronously updates logs and returns the affected row count.
-// Log modification must be enabled on the logstore using EnableLogStoreModify
-// or LogStore.EnableModify. This API does not create an asynchronous task.
+// Log modification must be enabled on the logstore (LogStore.EnableModify).
+// This API does not create an asynchronous task.
 func (c *Client) UpdateLogStoreLogs(project, logstore string, req *UpdateLogStoreLogsRequest) (*UpdateLogStoreLogsResponse, error) {
 	if req == nil {
 		return nil, NewClientError(errors.New("update logs request must not be nil"))
@@ -44,6 +46,8 @@ func (c *Client) UpdateLogStoreLogs(project, logstore string, req *UpdateLogStor
 // DeleteLogStoreLogsRequest selects logs by time range and query, or by row ID.
 // From and To are required Unix timestamps in seconds defining [From, To),
 // including when selecting by row ID. The service validates the time range.
+// Specify Query or RowID; if both are set, the service gives RowID precedence.
+// Query accepts search expressions, not SQL or SPL.
 type DeleteLogStoreLogsRequest struct {
 	From  int64  `json:"from"`
 	To    int64  `json:"to"`
@@ -57,8 +61,8 @@ type DeleteLogStoreLogsResponse struct {
 }
 
 // DeleteLogStoreLogs synchronously deletes logs and returns the affected row count.
-// Log modification must be enabled on the logstore using EnableLogStoreModify
-// or LogStore.EnableModify. This API does not create an asynchronous task.
+// Log modification must be enabled on the logstore (LogStore.EnableModify).
+// This API does not create an asynchronous task.
 func (c *Client) DeleteLogStoreLogs(project, logstore string, req *DeleteLogStoreLogsRequest) (*DeleteLogStoreLogsResponse, error) {
 	if req == nil {
 		return nil, NewClientError(errors.New("delete logs request must not be nil"))

--- a/client_logstore_logs.go
+++ b/client_logstore_logs.go
@@ -9,13 +9,14 @@ import (
 )
 
 // UpdateLogStoreLogsRequest selects logs by time range and query, or by row ID.
-// From and To are Unix timestamps in seconds; nil omits the corresponding bound.
+// From and To are required Unix timestamps in seconds defining [From, To),
+// including when selecting by row ID. The service validates the time range.
 type UpdateLogStoreLogsRequest struct {
-	From  *int64 `json:"from,omitempty"`
-	To    *int64 `json:"to,omitempty"`
+	From  int64  `json:"from"`
+	To    int64  `json:"to"`
 	Query string `json:"query,omitempty"`
 	RowID string `json:"rowId,omitempty"`
-	// UpdateMode is passed through to the service.
+	// UpdateMode is full or partial; when omitted, the service defaults to partial.
 	UpdateMode string `json:"updateMode,omitempty"`
 	// Data is a JSON-encoded string containing the fields to update.
 	Data string `json:"data"`
@@ -41,10 +42,11 @@ func (c *Client) UpdateLogStoreLogs(project, logstore string, req *UpdateLogStor
 }
 
 // DeleteLogStoreLogsRequest selects logs by time range and query, or by row ID.
-// From and To are Unix timestamps in seconds; nil omits the corresponding bound.
+// From and To are required Unix timestamps in seconds defining [From, To),
+// including when selecting by row ID. The service validates the time range.
 type DeleteLogStoreLogsRequest struct {
-	From  *int64 `json:"from,omitempty"`
-	To    *int64 `json:"to,omitempty"`
+	From  int64  `json:"from"`
+	To    int64  `json:"to"`
 	Query string `json:"query,omitempty"`
 	RowID string `json:"rowId,omitempty"`
 }

--- a/client_logstore_logs_e2e_test.go
+++ b/client_logstore_logs_e2e_test.go
@@ -5,6 +5,7 @@ package sls_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -22,6 +23,9 @@ func TestLogStoreLogsE2E(t *testing.T) {
 	client.SetHTTPClient(&http.Client{Timeout: 30 * time.Second})
 	for _, atCreation := range []bool{true, false} {
 		t.Run(fmt.Sprintf("enableAtCreation=%t", atCreation), func(t *testing.T) {
+			if !atCreation && os.Getenv("LOG_TEST_ENABLE_EXISTING_MODIFY") != "true" {
+				t.Skip("requires service support and LOG_TEST_ENABLE_EXISTING_MODIFY=true")
+			}
 			store := fmt.Sprintf("go-log-mutations-%d", time.Now().UnixNano())
 			require.NoError(t, client.CreateLogStoreV2(cfg.Project, &sls.LogStore{
 				Name: store, TTL: 1, ShardCount: 1, EnableModify: atCreation,

--- a/client_logstore_logs_e2e_test.go
+++ b/client_logstore_logs_e2e_test.go
@@ -1,0 +1,111 @@
+//go:build e2e
+
+package sls_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil"
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogStoreLogsE2E creates and cleans up its own stores in LOG_TEST_PROJECT.
+func TestLogStoreLogsE2E(t *testing.T) {
+	testutil.RequireE2E(t)
+	cfg, _ := testutil.LoadE2EConfig()
+	client := sls.CreateNormalInterface(cfg.Endpoint, cfg.AccessKeyID, cfg.AccessKeySecret, "")
+	client.SetHTTPClient(&http.Client{Timeout: 30 * time.Second})
+	for _, atCreation := range []bool{true, false} {
+		t.Run(fmt.Sprintf("enableAtCreation=%t", atCreation), func(t *testing.T) {
+			store := fmt.Sprintf("go-log-mutations-%d", time.Now().UnixNano())
+			require.NoError(t, client.CreateLogStoreV2(cfg.Project, &sls.LogStore{
+				Name: store, TTL: 1, ShardCount: 1, EnableModify: atCreation,
+			}))
+			t.Logf("created temporary logstore %s", store)
+			t.Cleanup(func() { require.NoError(t, client.DeleteLogStore(cfg.Project, store)) })
+			if !atCreation {
+				require.NoError(t, client.EnableLogStoreModify(cfg.Project, store))
+			}
+			require.Eventually(t, func() bool {
+				got, err := client.GetLogStore(cfg.Project, store)
+				return err == nil && got.EnableModify
+			}, 3*time.Minute, 3*time.Second)
+			index := sls.CreateDefaultIndex()
+			index.Keys = map[string]sls.IndexKey{"id": {Type: "text", Token: []string{}}, "status": {Type: "text", Token: []string{}}}
+			require.NoError(t, client.CreateIndex(cfg.Project, store, *index))
+			_, err := client.GetIndex(cfg.Project, store)
+			require.NoError(t, err)
+			// Allow the index configuration to reach the data plane before writing.
+			time.Sleep(10 * time.Second)
+			now := time.Now().Unix()
+			group := &sls.LogGroup{}
+			for _, id := range []string{"query", "row"} {
+				group.Logs = append(group.Logs, &sls.Log{Time: proto.Uint32(uint32(now)), Contents: []*sls.LogContent{
+					{Key: proto.String("id"), Value: proto.String(id)},
+					{Key: proto.String("status"), Value: proto.String("before")},
+				}})
+			}
+			require.NoError(t, client.PutLogs(cfg.Project, store, group))
+			query := func() (*sls.GetLogsResponse, error) {
+				return client.GetLogsV2(cfg.Project, store, &sls.GetLogRequest{From: now - 1, To: now + 2, Query: "*", Lines: 100})
+			}
+			var rows []map[string]string
+			require.Eventually(t, func() bool {
+				got, err := query()
+				if err != nil || got.Progress != "Complete" || len(got.Logs) != 2 {
+					return false
+				}
+				rows = got.Logs
+				return true
+			}, 3*time.Minute, 3*time.Second)
+			for _, row := range rows {
+				req := &sls.UpdateLogStoreLogsRequest{From: now - 1, To: now + 2, UpdateMode: "partial", Data: `{"status":"after"}`}
+				if row["id"] == "query" {
+					req.Query = "id:query"
+				} else {
+					require.NotEmpty(t, row["__rowid__"])
+					req.RowID = row["__rowid__"]
+				}
+				updated, err := client.UpdateLogStoreLogs(cfg.Project, store, req)
+				require.NoError(t, err)
+				require.Equal(t, int64(1), updated.AffectedRows)
+				t.Logf("updated %s: affectedRows=%d", row["id"], updated.AffectedRows)
+			}
+			require.Eventually(t, func() bool {
+				got, err := query()
+				if err != nil || got.Progress != "Complete" || len(got.Logs) != 2 {
+					return false
+				}
+				for _, row := range got.Logs {
+					if row["status"] != "after" {
+						return false
+					}
+				}
+				rows = got.Logs
+				return true
+			}, 3*time.Minute, 3*time.Second)
+			for _, row := range rows {
+				req := &sls.DeleteLogStoreLogsRequest{From: now - 1, To: now + 2}
+				if row["id"] == "query" {
+					req.Query = "id:query"
+				} else {
+					require.NotEmpty(t, row["__rowid__"])
+					req.RowID = row["__rowid__"]
+				}
+				deleted, err := client.DeleteLogStoreLogs(cfg.Project, store, req)
+				require.NoError(t, err)
+				require.Equal(t, int64(1), deleted.AffectedRows)
+				t.Logf("deleted %s: affectedRows=%d", row["id"], deleted.AffectedRows)
+			}
+			require.Eventually(t, func() bool {
+				got, err := query()
+				return err == nil && got.Progress == "Complete" && len(got.Logs) == 0
+			}, 3*time.Minute, 3*time.Second)
+		})
+	}
+}

--- a/client_logstore_logs_test.go
+++ b/client_logstore_logs_test.go
@@ -20,20 +20,19 @@ func TestLogStoreLogs(t *testing.T) {
 			t.Run(operation+"/"+selector, func(t *testing.T) {
 				transport := testutil.NewMockTransport()
 				client := clienthelper.NewMockedClient(transport)
-				expected := map[string]interface{}{}
-				var from, to *int64
+				from, to := int64(0), int64(1700000000)
+				expected := map[string]interface{}{"from": float64(from), "to": float64(to)}
 				var query, rowID string
 				if selector == "query" {
-					start, end := int64(0), int64(1700000000)
-					from, to, query = &start, &end, "status:error"
-					expected["from"], expected["to"], expected["query"] = float64(start), float64(end), query
+					query = "status:error"
+					expected["query"] = query
 				} else {
 					rowID = "row-123"
 					expected["rowId"] = rowID
 				}
 				data := `{"status":"已处理"}`
 				if operation == "update" {
-					expected["data"], expected["updateMode"] = data, "replace"
+					expected["data"], expected["updateMode"] = data, "partial"
 				}
 				calls := 0
 				transport.RegisterResponder(http.MethodPost, "http://project."+clienthelper.MockEndpoint+"/logstores/store/"+operation+"logs", func(req *http.Request) (*http.Response, error) {
@@ -48,7 +47,7 @@ func TestLogStoreLogs(t *testing.T) {
 					return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"affectedRows":4294967296}`)), Header: make(http.Header)}, nil
 				})
 				if operation == "update" {
-					resp, err := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{From: from, To: to, Query: query, RowID: rowID, UpdateMode: "replace", Data: data})
+					resp, err := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{From: from, To: to, Query: query, RowID: rowID, UpdateMode: "partial", Data: data})
 					require.NoError(t, err)
 					require.Equal(t, int64(4294967296), resp.AffectedRows)
 				} else {
@@ -82,7 +81,7 @@ func TestLogStoreLogsResponses(t *testing.T) {
 				})
 				var err error
 				if operation == "update" {
-					resp, e := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{RowID: "row", Data: `{}`})
+					resp, e := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{From: 1700000000, To: 1700000100, RowID: "row", Data: `{}`})
 					err = e
 					if tc.wantError {
 						require.Nil(t, resp)
@@ -90,7 +89,7 @@ func TestLogStoreLogsResponses(t *testing.T) {
 						require.Equal(t, int64(0), resp.AffectedRows)
 					}
 				} else {
-					resp, e := client.DeleteLogStoreLogs("project", "store", &sls.DeleteLogStoreLogsRequest{RowID: "row"})
+					resp, e := client.DeleteLogStoreLogs("project", "store", &sls.DeleteLogStoreLogsRequest{From: 1700000000, To: 1700000100, RowID: "row"})
 					err = e
 					if tc.wantError {
 						require.Nil(t, resp)
@@ -124,5 +123,32 @@ func TestLogStoreLogsValidation(t *testing.T) {
 		require.Error(t, err)
 		_, err = client.DeleteLogStoreLogs(target[0], target[1], &sls.DeleteLogStoreLogsRequest{})
 		require.Error(t, err)
+	}
+}
+
+// Range validation belongs to the service, and even zero bounds must be sent.
+func TestLogStoreLogsTimeRangePassthrough(t *testing.T) {
+	for _, bounds := range [][2]int64{{0, 0}, {10, 5}} {
+		transport := testutil.NewMockTransport()
+		client := clienthelper.NewMockedClient(transport)
+		calls := 0
+		for _, operation := range []string{"updatelogs", "deletelogs"} {
+			transport.RegisterResponder(http.MethodPost, "http://project."+clienthelper.MockEndpoint+"/logstores/store/"+operation, func(req *http.Request) (*http.Response, error) {
+				calls++
+				var body map[string]interface{}
+				require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+				require.Equal(t, float64(bounds[0]), body["from"])
+				require.Equal(t, float64(bounds[1]), body["to"])
+				return &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader(`{"errorCode":"InvalidParameter","errorMessage":"invalid time range"}`)), Header: make(http.Header)}, nil
+			})
+		}
+		_, err := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{From: bounds[0], To: bounds[1], RowID: "row", Data: `{}`})
+		var serviceError *sls.Error
+		require.ErrorAs(t, err, &serviceError)
+		require.Equal(t, "invalid time range", serviceError.Message)
+		_, err = client.DeleteLogStoreLogs("project", "store", &sls.DeleteLogStoreLogsRequest{From: bounds[0], To: bounds[1], RowID: "row"})
+		require.ErrorAs(t, err, &serviceError)
+		require.Equal(t, "invalid time range", serviceError.Message)
+		require.Equal(t, 2, calls)
 	}
 }

--- a/client_logstore_logs_test.go
+++ b/client_logstore_logs_test.go
@@ -152,3 +152,30 @@ func TestLogStoreLogsTimeRangePassthrough(t *testing.T) {
 		require.Equal(t, 2, calls)
 	}
 }
+
+func TestUpdateLogStoreLogsOptionalFields(t *testing.T) {
+	for _, mode := range []string{"", "full", "partial"} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			transport := testutil.NewMockTransport()
+			client := clienthelper.NewMockedClient(transport)
+			calls := 0
+			transport.RegisterResponder(http.MethodPost, "http://project."+clienthelper.MockEndpoint+"/logstores/store/updatelogs", func(req *http.Request) (*http.Response, error) {
+				calls++
+				var body map[string]interface{}
+				require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+				require.NotContains(t, body, "data")
+				if mode == "" {
+					require.NotContains(t, body, "updateMode")
+				} else {
+					require.Equal(t, mode, body["updateMode"])
+				}
+				require.Equal(t, "id:query", body["query"])
+				require.Equal(t, "row", body["rowId"])
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"affectedRows":0}`)), Header: make(http.Header)}, nil
+			})
+			_, err := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{From: 1, To: 2, Query: "id:query", RowID: "row", UpdateMode: mode})
+			require.NoError(t, err)
+			require.Equal(t, 1, calls)
+		})
+	}
+}

--- a/client_logstore_logs_test.go
+++ b/client_logstore_logs_test.go
@@ -1,0 +1,128 @@
+package sls_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil"
+	"github.com/aliyun/aliyun-log-go-sdk/internal/testutil/clienthelper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogStoreLogs(t *testing.T) {
+	for _, operation := range []string{"update", "delete"} {
+		for _, selector := range []string{"query", "rowID"} {
+			t.Run(operation+"/"+selector, func(t *testing.T) {
+				transport := testutil.NewMockTransport()
+				client := clienthelper.NewMockedClient(transport)
+				expected := map[string]interface{}{}
+				var from, to *int64
+				var query, rowID string
+				if selector == "query" {
+					start, end := int64(0), int64(1700000000)
+					from, to, query = &start, &end, "status:error"
+					expected["from"], expected["to"], expected["query"] = float64(start), float64(end), query
+				} else {
+					rowID = "row-123"
+					expected["rowId"] = rowID
+				}
+				data := `{"status":"已处理"}`
+				if operation == "update" {
+					expected["data"], expected["updateMode"] = data, "replace"
+				}
+				calls := 0
+				transport.RegisterResponder(http.MethodPost, "http://project."+clienthelper.MockEndpoint+"/logstores/store/"+operation+"logs", func(req *http.Request) (*http.Response, error) {
+					calls++
+					raw, err := io.ReadAll(req.Body)
+					require.NoError(t, err)
+					var body map[string]interface{}
+					require.NoError(t, json.Unmarshal(raw, &body))
+					require.Equal(t, expected, body)
+					require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+					require.Equal(t, strconv.Itoa(len(raw)), req.Header.Get("x-log-bodyrawsize"))
+					return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"affectedRows":4294967296}`)), Header: make(http.Header)}, nil
+				})
+				if operation == "update" {
+					resp, err := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{From: from, To: to, Query: query, RowID: rowID, UpdateMode: "replace", Data: data})
+					require.NoError(t, err)
+					require.Equal(t, int64(4294967296), resp.AffectedRows)
+				} else {
+					resp, err := client.DeleteLogStoreLogs("project", "store", &sls.DeleteLogStoreLogsRequest{From: from, To: to, Query: query, RowID: rowID})
+					require.NoError(t, err)
+					require.Equal(t, int64(4294967296), resp.AffectedRows)
+				}
+				require.Equal(t, 1, calls)
+			})
+		}
+	}
+}
+
+func TestLogStoreLogsResponses(t *testing.T) {
+	for _, operation := range []string{"update", "delete"} {
+		for _, tc := range []struct {
+			name, body string
+			status     int
+			wantError  bool
+		}{
+			{"zero", `{"affectedRows":0}`, 200, false},
+			{"invalidJSON", `{`, 200, true},
+			{"invalidCount", `{"affectedRows":"bad"}`, 200, true},
+			{"serviceError", `{"errorCode":"InvalidParameter","errorMessage":"bad selector"}`, 400, true},
+		} {
+			t.Run(operation+"/"+tc.name, func(t *testing.T) {
+				transport := testutil.NewMockTransport()
+				client := clienthelper.NewMockedClient(transport)
+				transport.RegisterResponder(http.MethodPost, "http://project."+clienthelper.MockEndpoint+"/logstores/store/"+operation+"logs", func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: tc.status, Body: io.NopCloser(strings.NewReader(tc.body)), Header: make(http.Header)}, nil
+				})
+				var err error
+				if operation == "update" {
+					resp, e := client.UpdateLogStoreLogs("project", "store", &sls.UpdateLogStoreLogsRequest{RowID: "row", Data: `{}`})
+					err = e
+					if tc.wantError {
+						require.Nil(t, resp)
+					} else {
+						require.Equal(t, int64(0), resp.AffectedRows)
+					}
+				} else {
+					resp, e := client.DeleteLogStoreLogs("project", "store", &sls.DeleteLogStoreLogsRequest{RowID: "row"})
+					err = e
+					if tc.wantError {
+						require.Nil(t, resp)
+					} else {
+						require.Equal(t, int64(0), resp.AffectedRows)
+					}
+				}
+				if tc.wantError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				if tc.status == 400 {
+					var serviceError *sls.Error
+					require.ErrorAs(t, err, &serviceError)
+					require.Equal(t, "InvalidParameter", serviceError.Code)
+				}
+			})
+		}
+	}
+}
+
+func TestLogStoreLogsValidation(t *testing.T) {
+	client := clienthelper.NewMockedClient(testutil.NewMockTransport())
+	_, err := client.UpdateLogStoreLogs("project", "store", nil)
+	require.Error(t, err)
+	_, err = client.DeleteLogStoreLogs("project", "store", nil)
+	require.Error(t, err)
+	for _, target := range [][2]string{{"", "store"}, {"project", ""}} {
+		_, err = client.UpdateLogStoreLogs(target[0], target[1], &sls.UpdateLogStoreLogsRequest{})
+		require.Error(t, err)
+		_, err = client.DeleteLogStoreLogs(target[0], target[1], &sls.DeleteLogStoreLogsRequest{})
+		require.Error(t, err)
+	}
+}

--- a/client_logstore_modify_test.go
+++ b/client_logstore_modify_test.go
@@ -46,3 +46,19 @@ func TestEnableLogStoreModify(t *testing.T) {
 
 	require.NoError(t, client.EnableLogStoreModify(project, logstore))
 }
+
+func TestCreateLogStoreWithEnableModify(t *testing.T) {
+	transport := testutil.NewMockTransport()
+	client := clienthelper.NewMockedClient(transport)
+	calls := 0
+	transport.RegisterResponder(http.MethodPost, "http://my-project."+clienthelper.MockEndpoint+"/logstores", func(req *http.Request) (*http.Response, error) {
+		calls++
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+		require.Equal(t, true, body["enableModify"])
+		require.Equal(t, "my-store", body["logstoreName"])
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	})
+	require.NoError(t, client.CreateLogStoreV2("my-project", &sls.LogStore{Name: "my-store", TTL: 1, ShardCount: 1, EnableModify: true}))
+	require.Equal(t, 1, calls)
+}

--- a/example/logstore/modify_logs/README.md
+++ b/example/logstore/modify_logs/README.md
@@ -1,0 +1,32 @@
+# Synchronous log updates and deletes
+
+Run from the repository root after setting:
+
+- `SLS_ENDPOINT`: your SLS endpoint, including `https://`.
+- `SLS_PROJECT`: an existing test project.
+- `ALIBABA_CLOUD_ACCESS_KEY_ID` and `ALIBABA_CLOUD_ACCESS_KEY_SECRET`.
+- `ALIBABA_CLOUD_SECURITY_TOKEN`: optional STS security token.
+
+```bash
+go run ./example/logstore/modify_logs
+```
+
+The example creates its own one-shard Logstore with one-day retention and
+`EnableModify: true`. It writes one synthetic record, waits for it to become
+queryable, updates its status by query using `UpdateLogStoreLogs`, then deletes
+it by row ID using `DeleteLogStoreLogs`. Both operations print `AffectedRows`
+and verify their effects through queries. Deferred cleanup deletes the temporary
+Logstore, including on errors. A forced process termination can prevent cleanup;
+the created Logstore name is printed for manual cleanup if needed.
+
+The account needs Logstore/index management, write, query, and
+`log:UpdateLogStoreLogs` / `log:DeleteLogStoreLogs` permissions. The example only
+modifies data in its own temporary Logstore.
+
+Both APIs require `From` and `To` (Unix seconds, `[From, To)`). Query and RowID
+are alternatives; RowID takes precedence if both are supplied. Query supports
+search expressions, not SQL or SPL. Update `Data` is a JSON-encoded string;
+`partial` preserves other fields, while `full` replaces the entire record.
+
+API references: [UpdateLogs](https://help.aliyun.com/zh/sls/developer-reference/api-sls-2020-12-30-updatelogs),
+[DeleteLogs](https://help.aliyun.com/zh/sls/developer-reference/api-sls-2020-12-30-deletelogs).

--- a/example/logstore/modify_logs/main.go
+++ b/example/logstore/modify_logs/main.go
@@ -1,0 +1,123 @@
+// This example creates a temporary Logstore, updates and deletes a synthetic
+// log, and deletes the Logstore on exit. See README.md for configuration.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/gogo/protobuf/proto"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() (err error) {
+	for _, key := range []string{"SLS_ENDPOINT", "SLS_PROJECT", "ALIBABA_CLOUD_ACCESS_KEY_ID", "ALIBABA_CLOUD_ACCESS_KEY_SECRET"} {
+		if os.Getenv(key) == "" {
+			return fmt.Errorf("set %s before running this example", key)
+		}
+	}
+	project := os.Getenv("SLS_PROJECT")
+	client := sls.CreateNormalInterfaceV2(os.Getenv("SLS_ENDPOINT"), sls.NewStaticCredentialsProvider(
+		os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_ID"), os.Getenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET"), os.Getenv("ALIBABA_CLOUD_SECURITY_TOKEN"),
+	))
+	client.SetHTTPClient(&http.Client{Timeout: 30 * time.Second})
+	store := fmt.Sprintf("go-modify-example-%d", time.Now().UnixNano())
+	if err = client.CreateLogStoreV2(project, &sls.LogStore{Name: store, TTL: 1, ShardCount: 1, EnableModify: true}); err != nil {
+		return err
+	}
+	fmt.Println("Created", store, "with enableModify=true")
+	defer func() {
+		if cleanupErr := client.DeleteLogStore(project, store); cleanupErr != nil {
+			if err == nil {
+				err = fmt.Errorf("delete temporary logstore %s: %w", store, cleanupErr)
+			} else {
+				fmt.Fprintf(os.Stderr, "Cleanup %s failed: %v\n", store, cleanupErr)
+			}
+		} else {
+			fmt.Println("Cleaned up", store)
+		}
+	}()
+	if err = client.CreateIndex(project, store, *sls.CreateDefaultIndex()); err != nil {
+		return err
+	}
+	// Wait for the index configuration to reach the data plane before writing.
+	time.Sleep(10 * time.Second)
+	now := time.Now().Unix()
+	if err = client.PutLogs(project, store, &sls.LogGroup{Logs: []*sls.Log{{
+		Time: proto.Uint32(uint32(now)), Contents: []*sls.LogContent{
+			{Key: proto.String("message"), Value: proto.String("SDK example")},
+			{Key: proto.String("status"), Value: proto.String("before")},
+		},
+	}}}); err != nil {
+		return err
+	}
+
+	// From and To are required even for RowID operations. Their relationship is
+	// validated by the service. This example owns the entire temporary store.
+	request := &sls.GetLogRequest{From: now - 1, To: now + 2, Query: "*", Lines: 100}
+	rows, err := waitForLogs(client, project, store, request, "before")
+	if err != nil {
+		return err
+	}
+	rowID := rows[0]["__rowid__"]
+	if rowID == "" {
+		return fmt.Errorf("query did not return __rowid__")
+	}
+
+	// Query is an index search expression, not SQL or SPL. If RowID is also set,
+	// the service gives RowID precedence. Data is a JSON string, not a JSON object.
+	updated, err := client.UpdateLogStoreLogs(project, store, &sls.UpdateLogStoreLogsRequest{
+		From: request.From, To: request.To, Query: "*", UpdateMode: "partial", Data: `{"status":"after"}`,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Println("Updated affectedRows:", updated.AffectedRows)
+	if updated.AffectedRows != 1 {
+		return fmt.Errorf("expected one updated row, got %d", updated.AffectedRows)
+	}
+	if _, err = waitForLogs(client, project, store, request, "after"); err != nil {
+		return err
+	}
+
+	deleted, err := client.DeleteLogStoreLogs(project, store, &sls.DeleteLogStoreLogsRequest{
+		From: request.From, To: request.To, RowID: rowID,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Println("Deleted affectedRows:", deleted.AffectedRows)
+	if deleted.AffectedRows != 1 {
+		return fmt.Errorf("expected one deleted row, got %d", deleted.AffectedRows)
+	}
+	_, err = waitForLogs(client, project, store, request, "")
+	return err
+}
+
+func waitForLogs(client sls.ClientInterface, project, store string, req *sls.GetLogRequest, status string) ([]map[string]string, error) {
+	for deadline := time.Now().Add(3 * time.Minute); time.Now().Before(deadline); time.Sleep(3 * time.Second) {
+		resp, err := client.GetLogsV2(project, store, req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.Progress != "Complete" {
+			continue
+		}
+		if status == "" && len(resp.Logs) == 0 {
+			return resp.Logs, nil
+		}
+		if status != "" && len(resp.Logs) == 1 && resp.Logs[0]["status"] == status {
+			return resp.Logs, nil
+		}
+	}
+	return nil, fmt.Errorf("timed out waiting for logs with status %q", status)
+}

--- a/token_auto_update_client.go
+++ b/token_auto_update_client.go
@@ -2327,3 +2327,23 @@ func (c *TokenAutoUpdateClient) GetMetricStoreV2(project, name string) (metricSt
 	}
 	return
 }
+
+func (c *TokenAutoUpdateClient) UpdateLogStoreLogs(project, logstore string, req *UpdateLogStoreLogsRequest) (resp *UpdateLogStoreLogsResponse, err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		resp, err = c.logClient.UpdateLogStoreLogs(project, logstore, req)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}
+
+func (c *TokenAutoUpdateClient) DeleteLogStoreLogs(project, logstore string, req *DeleteLogStoreLogsRequest) (resp *DeleteLogStoreLogsResponse, err error) {
+	for i := 0; i < c.maxTryTimes; i++ {
+		resp, err = c.logClient.DeleteLogStoreLogs(project, logstore, req)
+		if !c.processError(err) {
+			return
+		}
+	}
+	return
+}


### PR DESCRIPTION
Go callers need synchronous log updates and deletes that return an affected row count. Add `UpdateLogStoreLogs` and `DeleteLogStoreLogs` using the same POST `/updatelogs` and `/deletelogs` JSON protocol as the Python and Java synchronous APIs.

- Support time/query and row-ID selectors, required time bounds (always serialized, including zero; range validation is left to the service), update mode, JSON-string update data, and 64-bit `AffectedRows`.
- Expose both methods through `Client`, `ClientInterface`, and `TokenAutoUpdateClient`.
- Add a runnable `example/logstore/modify_logs` example using environment credentials, a temporary enabled Logstore, query update, row-ID delete, result verification, and cleanup.
- Cover the existing `LogStore.EnableModify` creation field and `EnableLogStoreModify` API (already on master via #386) with HTTP request tests and a reusable E2E test. Add usage and test documentation.
- Add the v0.1.129 entry to the existing change record. Releases are versioned by Git tags; no release tag is created by this PR. Custom `ClientInterface` implementations need the two new methods.

Validation: Docker build image, `go test ./...`, `go build ./...`, and focused mutation/enableModify tests. Tests cover the HTTP method/path/body/headers, row-ID and query selectors, required and zero timestamps, server-side validation of equal/reversed time ranges, large and zero affected counts, malformed responses, service errors, and invalid targets. The live E2E test passed for both enable-at-creation and enable-after-creation paths: query and row-ID updates/deletes each returned affectedRows=1, query results confirmed updated fields and then zero remaining rows, and both temporary Logstores were cleaned up. Command: `LOG_TEST_ENABLE_EXISTING_MODIFY=true go test -tags=e2e . -run ^TestLogStoreLogsE2E$ -v -count=1 -timeout=20m`. Existing-store enablement is opt-in because availability depends on the target service.

Compared against the official [UpdateLogs](https://help.aliyun.com/zh/sls/developer-reference/api-sls-2020-12-30-updatelogs) and [DeleteLogs](https://help.aliyun.com/zh/sls/developer-reference/api-sls-2020-12-30-deletelogs) references: required time bounds are always sent; optional data/mode are omitted when unset; selector precedence and search-only query syntax are documented. Creation-time enablement is the documented baseline; existing-store enablement is not advertised as universally available.

Self-review completed for protocol compatibility, Go 1.19-compatible syntax, interface integration, change scope, and committed content.




The runnable example also passed against a test service: one update and one delete each returned affectedRows=1, query checks passed, and the temporary Logstore was cleaned up.
