### PR TITLE
docs: remove release summaries from breaking changes

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,21 +1,5 @@
 # Breaking Changes
 
-## v0.1.129 (2026-09-08)
-
-### ClientInterface additions
-
-- Added synchronous `UpdateLogStoreLogs` and `DeleteLogStoreLogs` APIs returning `affectedRows`, with support in `Client` and `TokenAutoUpdateClient`. Custom implementations of `ClientInterface` must implement these two methods.
-- Added a runnable example for creation-time enablement, synchronous updates/deletes, and resource cleanup.
-- Added creation-time `EnableModify` request coverage and an E2E test for both enablement paths followed by synchronous update/delete.
-- Enable log modification with `LogStore.EnableModify` at creation; the existing `EnableLogStoreModify` API requires support from the target service.
-
-## v0.1.128 (2026-09-07)
-
-### MetricStore default change
-
-- The deprecated `CreateMetricStore` path now creates MetricStore V2 by using the `labels` type for `__labels__` in the default `prom` substore.
-- Substore key validation now accepts the `labels` type.
-
 ## v0.1.124 (2026-08-06)
 
 ### ⚠️ Module Change: Store View Routing Checker


### PR DESCRIPTION
Remove the v0.1.129 feature summary and v0.1.128 fix summary from BREAKING_CHANGES.md. Both releases already have GitHub Release notes; the breaking-change document should not serve as a general release changelog.

The v0.1.124 and v0.1.117 migration notes are unchanged. This is a documentation-only correction, with no code, dependency, or release-tag changes.

Validation: reviewed the complete diff, confirmed all remaining content is unchanged, and ran git diff --check. No build or runtime tests are needed for this Markdown-only removal.
